### PR TITLE
feat: async capabilites for updating context

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ const MyComponent = ({ userId }) => {
     // context is updated with userId
     updateContext({ userId })
   }, [])
+
+  useEffect(async () => {
+    // Can wait for the new flags to pull in from the different context
+    await updateContext({ userId });
+
+    console.log('new flags loaded for', userId);
+  }, []);
 }
 
 ```

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ts-loader": "^9.1.1",
     "ts-node": "^10.2.1",
     "typescript": "^4.4.3",
-    "unleash-proxy-client": "^1.6.0",
+    "unleash-proxy-client": "^1.7.0",
     "webpack": "^5.35.1",
     "webpack-cli": "^4.6.0"
   }

--- a/src/FlagProvider.test.tsx
+++ b/src/FlagProvider.test.tsx
@@ -95,7 +95,7 @@ test('A consumer that subscribes AFTER client init shows values from provider an
   expect(isEnabledMock).toHaveBeenCalledWith(givenFlagName);
   expect(updateContextMock).toHaveBeenCalledWith(givenContext);
   expect(screen.getByText(/consuming value isEnabled/)).toHaveTextContent('consuming value isEnabled true')
-  expect(screen.getByText(/consuming value updateContext/)).toHaveTextContent('consuming value updateContext undefined')
+  expect(screen.getByText(/consuming value updateContext/)).toHaveTextContent('consuming value updateContext [object Promise]')
   expect(screen.getByText(/consuming value getVariant/)).toHaveTextContent('consuming value getVariant A')
   expect(screen.getByText(/consuming value on/)).toHaveTextContent('consuming value on subscribed')
 

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -25,12 +25,12 @@ const FlagProvider: React.FC<IFlagProvider> = ({ config, children }) => {
     client.start();
   }, []);
 
-  const updateContext = (context: IContext) => {
+  const updateContext = async (context: IContext): Promise<void> => {
     if (!client) {
-      deferCall((client: any) => client.updateContext(context));
+      deferCall(async (client: any) => await client.updateContext(context));
       return;
     }
-    client.updateContext(context);
+    await client.updateContext(context);
   };
 
   const deferCall = (callback: (client: any) => void) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4029,10 +4029,10 @@ universalify@^0.1.2:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
-unleash-proxy-client@^1.6.0:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-1.6.1.tgz#d895932878d57823b2c9cfb1b2430a43863ee39d"
-  integrity sha512-85CrhAHXKby+hAc3FkMZsXURemQNZP9GriwpR4rCC7ffw8rktAXPcK3AjAzOu0Sp2V+ol5Ed4eo64oAcabaAHg==
+unleash-proxy-client@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-1.7.0.tgz#ece891ab256ae51b68572b5682c3586f2c5b10f7"
+  integrity sha512-QjThikkSKC82vtGF4LmiZlr8tO9H2Sowgw1WIIcOD1EYzcUmCNWKCFvUyjR2gEHTkjivO2v7tGh0gka/YJ+M1A==
   dependencies:
     "@react-native-async-storage/async-storage" "^1.15.5"
     tiny-emitter "^2.1.0"


### PR DESCRIPTION
Problem:
Currently there is no way to wait on the resolution of the new flags for when the unleash context was updated.

Usually there is no problem as you fire updateContext and forget, but you can observe it as a problem when you have a side effect ( like redirecting the page ) and you need the new unleash variants / values before executing the side-effect. (  As an example usually you want to store user variants in analytics for A/B testing ) 

Currently there is no way to wait on the resolution of the flags after the context was updated. This PR addresses this, it has been tested manually and all tests are passing.

This is backwards compatible as consumers can still fire and forget like before, but now can also wait for the updateContext to finish.

Updated to latest unleash-proxy-client-js 1.7.0 which makes the updateContext async