### PR TITLE
feat: allow using FlagProvider with SSR

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 export type { IConfig } from 'unleash-proxy-client';
 import FlagProvider from './FlagProvider';
+import FlagContext from './FlagContext';
 import useFlag from './useFlag';
 import useFlagsStatus from './useFlagsStatus';
 import useVariant from './useVariant';
 import useUnleashContext from './useUnleashContext';
 
-export { FlagProvider, useFlag, useFlagsStatus, useVariant, useUnleashContext };
+export { FlagContext, FlagProvider, useFlag, useFlagsStatus, useVariant, useUnleashContext };
 
 export default FlagProvider;


### PR DESCRIPTION
Hello, I wanted to use `@unleash/proxy-client-react` at Superside, but it doesn't work well with server-side rendering.

The main problem in your module is the use of `useEffect` hooks that are not executed at all on the server. In addition, I wanted to synchronously bootstrap `unleash-proxy-client` with toggles that have been passed from the server - this is not possible either.

I ended up with forking your repository for now and implementing the features myself. However, I would love to see support for SSR built-in and not having to maintain our custom fork.

Thanks!