### PR TITLE
Feat/ssr

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy-client-react",
-  "version": "1.0.1",
+  "version": "1.0.2-alpha.0",
   "description": "React interface for working with unleash",
   "main": "./dist/index.js",
   "types": "./dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ts-loader": "^9.1.1",
     "ts-node": "^10.2.1",
     "typescript": "^4.4.3",
-    "unleash-proxy-client": "Unleash/unleash-proxy-client-js#master",
+    "unleash-proxy-client": "1.9.0-alpha.0",
     "webpack": "^5.35.1",
     "webpack-cli": "^4.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy-client-react",
-  "version": "1.0.2-alpha.0",
+  "version": "1.0.2-alpha.1",
   "description": "React interface for working with unleash",
   "main": "./dist/index.js",
   "types": "./dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ts-loader": "^9.1.1",
     "ts-node": "^10.2.1",
     "typescript": "^4.4.3",
-    "unleash-proxy-client": "^1.7.0",
+    "unleash-proxy-client": "Unleash/unleash-proxy-client-js#master",
     "webpack": "^5.35.1",
     "webpack-cli": "^4.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy-client-react",
-  "version": "1.0.2-alpha.2",
+  "version": "1.0.2-alpha.0",
   "description": "React interface for working with unleash",
   "main": "./dist/index.js",
   "types": "./dist/src/index.d.ts",
@@ -40,7 +40,7 @@
     "ts-loader": "^9.1.1",
     "ts-node": "^10.2.1",
     "typescript": "^4.4.3",
-    "unleash-proxy-client": "1.9.0-alpha.0",
+    "unleash-proxy-client": "1.9.0",
     "webpack": "^5.35.1",
     "webpack-cli": "^4.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy-client-react",
-  "version": "1.0.2-alpha.1",
+  "version": "1.0.2-alpha.2",
   "description": "React interface for working with unleash",
   "main": "./dist/index.js",
   "types": "./dist/src/index.d.ts",

--- a/src/FlagProvider.test.tsx
+++ b/src/FlagProvider.test.tsx
@@ -1,39 +1,51 @@
 /**
+ * @format
  * @jest-environment jsdom
  */
+
 import React, { useContext, useEffect, useState } from 'react';
-import { render, screen , RenderOptions} from '@testing-library/react';
+import { render, screen, RenderOptions } from '@testing-library/react';
 import * as UnleashClientModule from 'unleash-proxy-client';
 import FlagProvider from './FlagProvider';
 import FlagContext from './FlagContext';
 
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom';
 interface IFlagProvider {
   config: UnleashClientModule.IConfig;
 }
 interface renderConsumerOptions {
-  providerProps: IFlagProvider,
-  renderOptions: RenderOptions
+  providerProps: IFlagProvider;
+  renderOptions: RenderOptions;
 }
 
 const getVariantMock = jest.fn().mockReturnValue('A');
 const updateContextMock = jest.fn();
 const startClientMock = jest.fn();
 const onMock = jest.fn().mockReturnValue('subscribed');
-const isEnabledMock = jest.fn().mockReturnValue(true)
-const UnleashClientSpy:jest.SpyInstance = jest.spyOn(UnleashClientModule, 'UnleashClient');
+const isEnabledMock = jest.fn().mockReturnValue(true);
+const UnleashClientSpy: jest.SpyInstance = jest.spyOn(
+  UnleashClientModule,
+  'UnleashClient'
+);
 const givenConfig = {
   appName: 'my-app',
   clientKey: 'my-secret',
-  url: 'https://my-unleash-proxy'
-}
+  url: 'https://my-unleash-proxy',
+};
 const givenFlagName = 'test';
 const givenContext = { session: 'context' };
 
-UnleashClientSpy.mockReturnValue({ getVariant: getVariantMock, updateContext: updateContextMock , start:startClientMock , isEnabled: isEnabledMock, on: onMock });
+UnleashClientSpy.mockReturnValue({
+  getVariant: getVariantMock,
+  updateContext: updateContextMock,
+  start: startClientMock,
+  isEnabled: isEnabledMock,
+  on: onMock,
+});
 
 const FlagConsumerAfterClientInit = () => {
-  const { updateContext, isEnabled, getVariant, client, on } = useContext(FlagContext);
+  const { updateContext, isEnabled, getVariant, client, on } =
+    useContext(FlagContext);
   const [enabled, setIsEnabled] = useState('nothing');
   const [variant, setVariant] = useState('nothing');
   const [context, setContext] = useState('nothing');
@@ -42,12 +54,12 @@ const FlagConsumerAfterClientInit = () => {
   useEffect(() => {
     if (client) {
       setIsEnabled(isEnabled(givenFlagName));
-      setVariant(getVariant(givenFlagName))
+      setVariant(getVariant(givenFlagName));
       setContext(updateContext(givenContext));
       setCurrentOn(on('someEvent', 'someArgument'));
     }
-  }, [client])
-  
+  }, [client]);
+
   return (
     <>
       <div>{`consuming value isEnabled ${enabled}`}</div>
@@ -55,11 +67,12 @@ const FlagConsumerAfterClientInit = () => {
       <div>{`consuming value getVariant ${variant}`}</div>
       <div>{`consuming value on ${currentOn}`}</div>
     </>
-  )
-}
+  );
+};
 
 const FlagConsumerBeforeClientInit = () => {
-  const { updateContext, isEnabled, getVariant, client, on} = useContext(FlagContext);
+  const { updateContext, isEnabled, getVariant, client, on } =
+    useContext(FlagContext);
   const [enabled, setIsEnabled] = useState('nothing');
   const [variant, setVariant] = useState('nothing');
   const [context, setContext] = useState('nothing');
@@ -68,48 +81,103 @@ const FlagConsumerBeforeClientInit = () => {
   useEffect(() => {
     if (!client) {
       setIsEnabled(isEnabled(givenFlagName));
-      setVariant(getVariant(givenFlagName))
+      setVariant(getVariant(givenFlagName));
       setContext(updateContext(givenContext));
       setCurrentOn(on('someEvent', 'someArgument'));
     }
-  }, [])
-  
-  return <></>
-}
+  }, []);
 
-const renderConsumer = (ui: any, { providerProps, renderOptions} : renderConsumerOptions) => {
+  return <></>;
+};
+
+const renderConsumer = (
+  ui: any,
+  { providerProps, renderOptions }: renderConsumerOptions
+) => {
   return render(
     <FlagProvider config={providerProps.config}>{ui}</FlagProvider>,
-    renderOptions,
-  )
-}
+    renderOptions
+  );
+};
+
+const renderConsumerWithUnleashClient = (
+  ui: any,
+  { providerProps, renderOptions }: renderConsumerOptions
+) => {
+  const client = new UnleashClientModule.UnleashClient(
+    providerProps.config
+  );
+  return render(
+    <FlagProvider unleashClient={client}>{ui}</FlagProvider>,
+    renderOptions
+  );
+};
 
 test('A consumer that subscribes AFTER client init shows values from provider and calls all the functions', () => {
   const providerProps = {
-    config: givenConfig
-  }
-  
-  renderConsumer(<FlagConsumerAfterClientInit />, { providerProps, renderOptions: {} })
-  
+    config: givenConfig,
+  };
+
+  renderConsumer(<FlagConsumerAfterClientInit />, {
+    providerProps,
+    renderOptions: {},
+  });
+
   expect(getVariantMock).toHaveBeenCalledWith(givenFlagName);
   expect(isEnabledMock).toHaveBeenCalledWith(givenFlagName);
   expect(updateContextMock).toHaveBeenCalledWith(givenContext);
-  expect(screen.getByText(/consuming value isEnabled/)).toHaveTextContent('consuming value isEnabled true')
-  expect(screen.getByText(/consuming value updateContext/)).toHaveTextContent('consuming value updateContext [object Promise]')
-  expect(screen.getByText(/consuming value getVariant/)).toHaveTextContent('consuming value getVariant A')
-  expect(screen.getByText(/consuming value on/)).toHaveTextContent('consuming value on subscribed')
-
+  expect(screen.getByText(/consuming value isEnabled/)).toHaveTextContent(
+    'consuming value isEnabled true'
+  );
+  expect(
+    screen.getByText(/consuming value updateContext/)
+  ).toHaveTextContent('consuming value updateContext [object Promise]');
+  expect(screen.getByText(/consuming value getVariant/)).toHaveTextContent(
+    'consuming value getVariant A'
+  );
+  expect(screen.getByText(/consuming value on/)).toHaveTextContent(
+    'consuming value on subscribed'
+  );
 });
 
 test('A consumer that subscribes BEFORE client init shows values from provider and calls all the functions', () => {
   const providerProps = {
-    config: givenConfig
-  }
+    config: givenConfig,
+  };
 
-  renderConsumer(<FlagConsumerBeforeClientInit />, {providerProps, renderOptions:{}})
-  
+  renderConsumer(<FlagConsumerBeforeClientInit />, {
+    providerProps,
+    renderOptions: {},
+  });
+
   expect(getVariantMock).toHaveBeenCalledWith(givenFlagName);
   expect(isEnabledMock).toHaveBeenCalledWith(givenFlagName);
   expect(updateContextMock).toHaveBeenCalledWith(givenContext);
-})
+});
 
+test('A consumer should be able to get a variant when the client is passed into the provider as props', () => {
+  const providerProps = {
+    config: givenConfig,
+  };
+
+  renderConsumerWithUnleashClient(<FlagConsumerAfterClientInit />, {
+    providerProps,
+    renderOptions: {},
+  });
+
+  expect(getVariantMock).toHaveBeenCalledWith(givenFlagName);
+  expect(isEnabledMock).toHaveBeenCalledWith(givenFlagName);
+  expect(updateContextMock).toHaveBeenCalledWith(givenContext);
+  expect(screen.getByText(/consuming value isEnabled/)).toHaveTextContent(
+    'consuming value isEnabled true'
+  );
+  expect(
+    screen.getByText(/consuming value updateContext/)
+  ).toHaveTextContent('consuming value updateContext [object Promise]');
+  expect(screen.getByText(/consuming value getVariant/)).toHaveTextContent(
+    'consuming value getVariant A'
+  );
+  expect(screen.getByText(/consuming value on/)).toHaveTextContent(
+    'consuming value on subscribed'
+  );
+});

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -19,8 +19,9 @@ const FlagProvider: React.FC<IFlagProvider> = ({
   const client = React.useRef<UnleashClient>(unleashClient);
 
   if (!config && !unleashClient) {
-    throw new Error(
-      'You must provide either a config or an unleash client to the flag provider'
+    console.warn(
+      `You must provide either a config or an unleash client to the flag provider. If you are initializing the client in useEffect, you can avoid this warning by
+      checking if the client exists before rendering.`
     );
   }
 

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -18,6 +18,12 @@ const FlagProvider: React.FC<IFlagProvider> = ({
 }) => {
   const client = React.useRef<UnleashClient>(unleashClient);
 
+  if (!config && !unleashClient) {
+    throw new Error(
+      'You must provide either a config or an unleash client to the flag provider'
+    );
+  }
+
   if (!client.current) {
     client.current = new UnleashClient(config);
   }

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -4,6 +4,8 @@ import * as React from 'react';
 import FlagContext from './FlagContext';
 import { UnleashClient, IConfig, IContext } from 'unleash-proxy-client';
 
+type eventArgs = [Function, any];
+
 interface IFlagProvider {
   config?: IConfig;
   unleashClient?: UnleashClient;
@@ -14,68 +16,40 @@ const FlagProvider: React.FC<IFlagProvider> = ({
   children,
   unleashClient,
 }) => {
-  const [client, setClient] = React.useState(null);
-  const functionCalls = React.useRef<any>();
-  functionCalls.current = [];
+  const client = React.useRef<UnleashClient>(unleashClient);
+
+  if (!client.current) {
+    client.current = new UnleashClient(config);
+  }
 
   React.useEffect(() => {
-    let client: UnleashClient | null = null;
-    if (unleashClient) {
-      client = unleashClient;
-    } else {
-      client = new UnleashClient(config);
-    }
-
-    functionCalls.current.forEach((call: any) => {
-      call(client);
-    }, []);
-
-    functionCalls.current = [];
-
-    setClient(client);
-
-    client.start();
+    client.current.start();
   }, []);
 
   const updateContext = async (context: IContext): Promise<void> => {
-    if (!client) {
-      deferCall(
-        async (client: any) => await client.updateContext(context)
-      );
-      return;
-    }
-    await client.updateContext(context);
-  };
-
-  const deferCall = (callback: (client: any) => void) => {
-    functionCalls.current.push(callback);
+    await client.current.updateContext(context);
   };
 
   const isEnabled = (name: string) => {
-    if (!client) {
-      deferCall((client: any) => client.isEnabled(name));
-      return;
-    }
-    return client.isEnabled(name);
+    return client.current.isEnabled(name);
   };
 
   const getVariant = (name: string) => {
-    if (!client) {
-      deferCall((client: any) => client.getVariant(name));
-      return {};
-    }
-    return client.getVariant(name);
+    return client.current.getVariant(name);
   };
 
-  const on = (event: string, ...args: any[]) => {
-    if (!client) {
-      deferCall((client: any) => client.on(event, ...args));
-      return;
-    }
-    return client.on(event, ...args);
+  const on = (event: string, ...args: eventArgs) => {
+    return client.current.on(event, ...args);
   };
 
-  const context = { on, updateContext, isEnabled, getVariant, client };
+  const context = {
+    on,
+    updateContext,
+    isEnabled,
+    getVariant,
+    client: client.current,
+  };
+
   return (
     <FlagContext.Provider value={context}>{children}</FlagContext.Provider>
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,31 @@
-export type { IConfig } from 'unleash-proxy-client';
+/** @format */
+
+export type {
+  IConfig,
+  IContext,
+  IMutableContext,
+  IVariant,
+  IToggle,
+} from 'unleash-proxy-client';
+export {
+  UnleashClient,
+  IStorageProvider,
+  LocalStorageProvider,
+  InMemoryStorageProvider,
+} from 'unleash-proxy-client';
+
 import FlagProvider from './FlagProvider';
 import useFlag from './useFlag';
 import useFlagsStatus from './useFlagsStatus';
 import useVariant from './useVariant';
 import useUnleashContext from './useUnleashContext';
 
-export { FlagProvider, useFlag, useFlagsStatus, useVariant, useUnleashContext };
+export {
+  FlagProvider,
+  useFlag,
+  useFlagsStatus,
+  useVariant,
+  useUnleashContext,
+};
 
 export default FlagProvider;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4029,10 +4029,10 @@ universalify@^0.1.2:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
-unleash-proxy-client@1.9.0-alpha.0:
-  version "1.9.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-1.9.0-alpha.0.tgz#460d3c9541344d7541ed8b172f5c2fc00c3d6501"
-  integrity sha512-/9S1xYqj7BazKOB8C+r9ExX8fHycCP6dLQXosg7Iqt/WTrTHy5CvFqxRFcUwNx099BoOFNlfH49l0n/6bDehng==
+unleash-proxy-client@1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-1.9.0.tgz#e1d3bf0b78593e3ce523606f7759e43a59e44518"
+  integrity sha512-hOpqBp+31InfUvzUoXJc+dbHqepe4QmI3iSfpLER32tzK80iMTH6g9vg2QbBH1IobVwJrcRgLItjwtm/w0uWjQ==
   dependencies:
     "@react-native-async-storage/async-storage" "^1.15.5"
     tiny-emitter "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4029,9 +4029,10 @@ universalify@^0.1.2:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
-unleash-proxy-client@Unleash/unleash-proxy-client-js#master:
-  version "1.8.0"
-  resolved "https://codeload.github.com/Unleash/unleash-proxy-client-js/tar.gz/23aa2aef5c5396b150bbe50adaeb959c94db075d"
+unleash-proxy-client@1.9.0-alpha.0:
+  version "1.9.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-1.9.0-alpha.0.tgz#460d3c9541344d7541ed8b172f5c2fc00c3d6501"
+  integrity sha512-/9S1xYqj7BazKOB8C+r9ExX8fHycCP6dLQXosg7Iqt/WTrTHy5CvFqxRFcUwNx099BoOFNlfH49l0n/6bDehng==
   dependencies:
     "@react-native-async-storage/async-storage" "^1.15.5"
     tiny-emitter "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4029,10 +4029,9 @@ universalify@^0.1.2:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
-unleash-proxy-client@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-1.7.0.tgz#ece891ab256ae51b68572b5682c3586f2c5b10f7"
-  integrity sha512-QjThikkSKC82vtGF4LmiZlr8tO9H2Sowgw1WIIcOD1EYzcUmCNWKCFvUyjR2gEHTkjivO2v7tGh0gka/YJ+M1A==
+unleash-proxy-client@Unleash/unleash-proxy-client-js#master:
+  version "1.8.0"
+  resolved "https://codeload.github.com/Unleash/unleash-proxy-client-js/tar.gz/23aa2aef5c5396b150bbe50adaeb959c94db075d"
   dependencies:
     "@react-native-async-storage/async-storage" "^1.15.5"
     tiny-emitter "^2.1.0"


### PR DESCRIPTION
This PR aims to make this library easier to work with for SSR. It takes inspiration from #21, and will allow you to instantiate a client on the outside of the flagprovider that you can pass in instead of the configuration. This will allow you to prefetch data on the server side and pass it through to the client side unleash client by setting the bootstrap field with the data. This also fixes issues where you need to expose the client to other parts of the code that aren't using react.

Fixes #22