### PR TITLE
refactor: remove deferred function calls by using 'useMemo'

### DIFF
--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -7,58 +7,26 @@ interface IFlagProvider {
 }
 
 const FlagProvider: React.FC<IFlagProvider> = ({ config, children }) => {
-  const [client, setClient] = React.useState(null);
-  const functionCalls = React.useRef<any>();
-  functionCalls.current = [];
-
-  React.useEffect(() => {
+  const client = React.useMemo(() => {
     const client = new UnleashClient(config);
-
-    functionCalls.current.forEach((call: any) => {
-      call(client);
-    }, []);
-
-    functionCalls.current = [];
-
-    setClient(client);
-
     client.start();
+    return client;
   }, []);
 
   const updateContext = async (context: IContext): Promise<void> => {
-    if (!client) {
-      deferCall(async (client: any) => await client.updateContext(context));
-      return;
-    }
     await client.updateContext(context);
   };
 
-  const deferCall = (callback: (client: any) => void) => {
-    functionCalls.current.push(callback);
-  };
-
   const isEnabled = (name: string) => {
-    if (!client) {
-      deferCall((client: any) => client.isEnabled(name));
-      return;
-    }
     return client.isEnabled(name);
   };
 
   const getVariant = (name: string) => {
-    if (!client) {
-      deferCall((client: any) => client.getVariant(name));
-      return {};
-    }
     return client.getVariant(name);
   };
 
-  const on = (event:string, ...args:any[]) => {
-    if (!client) {
-      deferCall((client: any) => client.on(event,...args));
-      return;
-    }
-    return client.on(event, ...args);
+  const on = (...args:Parameters<typeof client.on>) => {
+    return client.on(...args);
   };
 
   const context = { on, updateContext, isEnabled, getVariant, client };


### PR DESCRIPTION
I'm looking to make changes according to https://github.com/Unleash/proxy-client-react/issues/22, but before I get started, I wanted to do this refactor in isolation. This way we can discuss it if anyone has questions.

In the former code, `useEffect` was being used more literally like `componentDidMount` for class components. While this works, since the `client` creation technically occurs on the 2nd pass of the context function, you see all the extra hoops to jump through with `deferCall`.

The spirit of this code is that the `client` is created up-front, exactly one time. `useMemo` accomplishes that, but this way, the `client` is defined on the first pass, allowing us to remove the `deferCall` code.

So to sum it up, nothing is different here, only better. I'll work on https://github.com/Unleash/proxy-client-react/issues/22 separately.