### PR TITLE
fix: memoize context provider value

### DIFF
--- a/src/FlagProvider.test.tsx
+++ b/src/FlagProvider.test.tsx
@@ -181,3 +181,34 @@ test('A consumer should be able to get a variant when the client is passed into 
     'consuming value on subscribed'
   );
 });
+
+test('A memoized consumer should not rerender when the context provider values are the same', () => {
+  const renderCounter = jest.fn();
+
+  const MemoizedConsumer = React.memo(() => {
+    const { updateContext, isEnabled, getVariant, client, on } =
+      useContext(FlagContext);
+
+    renderCounter();
+
+    return <></>;
+  });
+
+  expect(renderCounter).toHaveBeenCalledTimes(0);
+
+  const { rerender } = render(
+    <FlagProvider config={givenConfig}>
+      <MemoizedConsumer />
+    </FlagProvider>
+  );
+
+  expect(renderCounter).toHaveBeenCalledTimes(1);
+
+  rerender(
+    <FlagProvider config={givenConfig}>
+      <MemoizedConsumer />
+    </FlagProvider>
+  );
+
+  expect(renderCounter).toHaveBeenCalledTimes(1);
+});

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -49,13 +49,16 @@ const FlagProvider: React.FC<IFlagProvider> = ({
     return client.current.on(event, ...args);
   };
 
-  const context = {
-    on,
-    updateContext,
-    isEnabled,
-    getVariant,
-    client: client.current,
-  };
+  const context = React.useMemo(
+    () => ({
+      on,
+      updateContext,
+      isEnabled,
+      getVariant,
+      client: client.current,
+    }),
+    []
+  );
 
   return (
     <FlagContext.Provider value={context}>{children}</FlagContext.Provider>


### PR DESCRIPTION
Memoize the context provided value, so in a eventual rerender of the Provider, it does not force a rerender of a memoized consumer.

We should never pass a new object to the provider, otherwise it forces the rerender of every consumer. See: https://reactjs.org/docs/context.html#caveats