### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ const MyComponent = ({ userId }) => {
     updateContext({ userId })
   }, [userId])
 
-  useEffect(async () => {
+  useEffect(() => {
     async function run() {
     // Can wait for the new flags to pull in from the different context
       updateContext({ userId });

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ const MyComponent = ({ userId }) => {
   useEffect(() => {
     async function run() {
     // Can wait for the new flags to pull in from the different context
-      updateContext({ userId });
+      await updateContext({ userId });
       console.log('new flags loaded for', userId);
     }
     run();

--- a/README.md
+++ b/README.md
@@ -127,14 +127,16 @@ const MyComponent = ({ userId }) => {
   useEffect(() => {
     // context is updated with userId
     updateContext({ userId })
-  }, [])
+  }, [userId])
 
   useEffect(async () => {
+    async function run() {
     // Can wait for the new flags to pull in from the different context
-    await updateContext({ userId });
-
-    console.log('new flags loaded for', userId);
-  }, []);
+      updateContext({ userId });
+      console.log('new flags loaded for', userId);
+    }
+    run();
+  }, [userId]);
 }
 
 ```


### PR DESCRIPTION
There are wrong usage of `useEffect`, in the first one - missed dependency `userId` which may change and we should re-run effect for use actual userId

in the second one also wrong usage of `useEffect` - which first argument is not possible to be `async` function because `useEffect` first argument function should return cleanup function

I believe that examples should not demonstrate such mistakes