### PR TITLE
Make starting client on FlagProvider mount optional

### DIFF
--- a/src/FlagProvider.test.tsx
+++ b/src/FlagProvider.test.tsx
@@ -290,3 +290,28 @@ test('should register error when error event is sent', () => {
     expect.any(Function)
   );
 });
+
+test('should not start client if startClient is false', () => {
+  const localMock = jest.fn();
+  UnleashClientSpy.mockReturnValue({
+    getVariant: getVariantMock,
+    updateContext: updateContextMock,
+    start: localMock,
+    isEnabled: isEnabledMock,
+    on: onMock,
+  });
+
+  const providerProps = {
+    config: givenConfig,
+  };
+
+  const client = new UnleashClientModule.UnleashClient(providerProps.config);
+
+  render(
+    <FlagProvider unleashClient={client} startClient={false}>
+      <div>Hi</div>
+    </FlagProvider>
+  );
+
+  expect(localMock).not.toHaveBeenCalled();
+});

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -9,12 +9,14 @@ type eventArgs = [Function, any];
 interface IFlagProvider {
   config?: IConfig;
   unleashClient?: UnleashClient;
+  startClient?: boolean;
 }
 
 const FlagProvider: React.FC<IFlagProvider> = ({
   config,
   children,
   unleashClient,
+  startClient = true,
 }) => {
   const client = React.useRef<UnleashClient>(unleashClient);
   const [flagsReady, setFlagsReady] = React.useState(false);
@@ -40,7 +42,10 @@ const FlagProvider: React.FC<IFlagProvider> = ({
   });
 
   React.useEffect(() => {
-    client.current.start();
+    const shouldStartClient = startClient || !unleashClient;
+    if (shouldStartClient) {
+      client.current.start();
+    }
   }, []);
 
   const updateContext = async (context: IContext): Promise<void> => {


### PR DESCRIPTION
fixes https://github.com/Unleash/proxy-client-react/issues/45

Adds `startClient` option that is used to optionally disable starting the client on `FlagProvider` mount so that the creator can handle responsibility of starting and stopping the client.

Also adds a test to ensure that the client is not started when a client is passed in props and the `startClient` prop is false. This may not be necessary. Please let me know any feedback :)