### PR TITLE
docs: add docs for startClient option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ ReactDOM.render(
 );
 ```
 
-Defer starting of the client: 
+Defer starting the polling of the client (this allows you more fine grained control over when the client should fetch the feature flag configuration, for instance if you need context values that you are fetching from the server): 
 
 ```jsx
 ReactDOM.render(

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ npm install @unleash/proxy-client-react
 yarn add @unleash/proxy-client-react
 ```
 
+# Initialization
+
 Import the provider like this in your entrypoint file (typically index.js/ts):
 
 ```jsx
@@ -58,7 +60,11 @@ ReactDOM.render(
 );
 ```
 
-Defer starting the polling of the client (this allows you more fine grained control over when the client should fetch the feature flag configuration, for instance if you need context values that you are fetching from the server): 
+## Deferring client start
+
+By default, the Unleash client will start polling the Proxy for toggles immediately when the `FlagProvider` component renders. You can delay the polling by:
+- setting the `startClient` prop to `false`
+- passing a client instance to the `FlagProvider`
 
 ```jsx
 ReactDOM.render(
@@ -70,6 +76,35 @@ ReactDOM.render(
   document.getElementById('root')
 );
 ```
+
+Deferring the client start gives you more fine-grained control over when to start fetching the feature toggle configuration. This could be handy in cases where you need to get some other context data from the server before fetching toggles, for instance.
+
+To start the client, use the client's `start` method. The below snippet of pseudocode will defer polling until the end of the `asyncProcess` function.
+
+``` jsx
+const client = new UnleashClient({ /* ... */ })
+
+useEffect(() => {
+  const asyncProcess = async () => {
+    // do async work ...
+    client.start()
+  }
+  asyncProcess()
+, [])
+
+// Pass client as `unleashClient` and set `startClient` to `false`
+return <FlagProvider unleashClient={client} startClient={false} />
+
+return (
+  <FlagProvider unleashClient={client} startClient={false}>
+    <App />
+  </FlagProvider>
+)
+```
+
+# Usage
+
+## Check feature toggle status
 
 To check if a feature is enabled:
 
@@ -87,6 +122,8 @@ const TestComponent = () => {
 
 export default TestComponent;
 ```
+
+## Check variants
 
 To check variants:
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ ReactDOM.render(
 );
 ```
 
+Defer starting of the client: 
+
+```jsx
+ReactDOM.render(
+  <React.StrictMode>
+    <FlagProvider unleashClient={client} startClient={false}>
+      <App />
+    </FlagProvider>
+  </React.StrictMode>,
+  document.getElementById('root')
+);
+```
+
 To check if a feature is enabled:
 
 ```jsx


### PR DESCRIPTION
Documents the newly added startClient option. Merge when released.