### PR TITLE
Add explicit children to `IFlagProvider`

### DIFF
--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -12,7 +12,7 @@ interface IFlagProvider {
   startClient?: boolean;
 }
 
-const FlagProvider: React.FC<IFlagProvider> = ({
+const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
   config,
   children,
   unleashClient,


### PR DESCRIPTION
  React 18 will no longer allow "implicit children", so this commit adds
  this type to the `IFlagProvider` interface.
