### PR TITLE
docs: update README to use named export instead of default

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Upgrading should be as easy as running yarn again with the new version, but we m
 Import the provider like this in your entrypoint file (typically index.js/ts):
 
 ```jsx
-import FlagProvider from '@unleash/proxy-client-react';
+import { FlagProvider } from '@unleash/proxy-client-react';
 
 const config = {
   url: 'https://HOSTNAME/proxy',
@@ -47,7 +47,7 @@ ReactDOM.render(
 Alternatively, you can pass your own client in to the FlagProvider:
 
 ```jsx
-import FlagProvider, { UnleashClient } from '@unleash/proxy-client-react';
+import { FlagProvider, UnleashClient } from '@unleash/proxy-client-react';
 
 const config = {
   url: 'https://HOSTNAME/proxy',


### PR DESCRIPTION
## About the changes
Updated the README to specify using the named `FlagProvider` export instead of the default export, which was causing issues with Vite prod builds. See linked issue for more information. 

<!-- Does it close an issue? Multiple? -->
Closes #57.

### Important files
 - `README.md`

## Discussion points
We might want to remove the default export at a later major version and only use named exports.
