### PR TITLE
docs: add draft for server-side usage description to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,12 @@ If you want to use this client to evaluate feature client-side, then you need to
 <!-- Todo: explain what this is and how it works -->
 
 ```js
+import {
+    FlagProvider,
+    InMemoryStorageProvider,
+    UnleashClient
+} from '@unleash/proxy-client-react';
+
 export async function getServerSideProps() {
   // Set up unleash to fetch only once in order to not create
   // bindings for every request (which would cause a memory leak)
@@ -370,6 +376,12 @@ export async function getServerSideProps() {
 And then
 
 ```js
+import {
+    FlagProvider,
+    InMemoryStorageProvider,
+    UnleashClient
+} from '@unleash/proxy-client-react';
+
 // sample config
 const config = {
   url: 'https://app.unleash-hosted.com/demo/proxy',

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ You can use the client for server-side rendering in a few different ways, each o
 
 The examples below are tailored towards Next.js, but you should be able to adopt them to other settings.
 
-If you want to use this client to evaluate feature client-side, then you need to provide an alternative implementation of `fetch`, using the configuration's `fetch` property, and a storage provider, using the `storageProvider` property. By default, this client tries to use `window.fetch` to retrieve toggles for evaluation and `window.localStorage` as a storage provider, but `window` isn't available during server-side rendering.
+If you want to use this client to evaluate features server-side, then you need to provide an alternative implementation of `fetch`, using the configuration's `fetch` property, and a storage provider, using the `storageProvider` property. By default, this client tries to use `window.fetch` to retrieve toggles for evaluation and `window.localStorage` as a storage provider, but `window` isn't available during server-side rendering.
 
 ### Prefetching toggles (Next.js)
 

--- a/README.md
+++ b/README.md
@@ -317,9 +317,13 @@ Wrap your components like so:
 
 ## Server-side rendering (SSR) / Next.js
 
-> **Notice:** This client SDK _can_ be used with server-side rendering (SSR). However, it does require you to make certain changes, as detailed below. First-class support for SSR is something we'd like to look into, but it is not prioritized at the moment. If you'd like to help us improve the support, let us know in an issue/PR or [on Slack](slack.unleash.run)!
->
-> The code samples below are adapted from issues [#40](https://github.com/Unleash/proxy-client-react/issues/40#issuecomment-1048761755 "GitHub issue #40") and [#50](https://github.com/Unleash/proxy-client-react/issues/50 "GitHub issue #50"). Refer to the issues for more information and context.
+-----
+
+**⚠️ Note:️**This client SDK _can_ be used with server-side rendering (SSR). However, it does require you to make certain changes, as detailed below. First-class support for SSR is something we'd like to look into, but it is not prioritized at the moment. If you'd like to help us improve the support, let us know in an issue/PR or [on Slack](slack.unleash.run)!
+
+The code samples below are adapted from issues [#40](https://github.com/Unleash/proxy-client-react/issues/40#issuecomment-1048761755 "GitHub issue #40") and [#50](https://github.com/Unleash/proxy-client-react/issues/50 "GitHub issue #50"). Refer to these issues for more information and context.
+
+-----
 
 You can use the client for server-side rendering in a few different ways, each of which have their own advantages and drawbacks. The three main ways are:
 

--- a/README.md
+++ b/README.md
@@ -314,3 +314,89 @@ Wrap your components like so:
       )}
     />
 ```
+
+## Server-side rendering (SSR) / Next.js
+
+> **Notice:** This client SDK _can_ be used with server-side rendering (SSR). However, it does require you to make certain changes, as detailed below. First-class support for SSR is something we'd like to look into, but it is not prioritized at the moment. If you'd like to help us improve the support, let us know in an issue/PR or [on Slack](slack.unleash.run)!
+>
+> The code samples below are adapted from issues [#40](https://github.com/Unleash/proxy-client-react/issues/40#issuecomment-1048761755 "GitHub issue #40") and [#50](https://github.com/Unleash/proxy-client-react/issues/50 "GitHub issue #50"). Refer to the issues for more information and context.
+
+You can use the client for server-side rendering in a few different ways, each of which have their own advantages and drawbacks. The three main ways are:
+
+| Method                                                           | Advantage                                                 | Drawback                                                                                                               |
+|------------------------------------------------------------------|-----------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| Per-request toggle fetching                                      | You'll always get the most up-to-date toggle state.       | You must wait for the client to start and to fetch toggles before rendering.                                           |
+| Global server-side Unleash client                                | You can render pages server-side  with toggles evaluated. | The toggle state can be as old as the defined refresh interval.                                                        |
+| Defer starting the client until the page is rendered client-side | Less work to implement, faster response times.            | The work is pushed to the client side, so the features the end-user see might change after the client is instantiated. |
+
+The examples below are tailored towards Next.js, but you should be able to adopt them to other settings.
+
+If you want to use this client to evaluate feature client-side, then you need to provide an alternative implementation of `fetch`, using the configuration's `fetch` property, and a storage provider, using the `storageProvider` property. By default, this client tries to use `window.fetch` to retrieve toggles for evaluation and `window.localStorage` as a storage provider, but `window` isn't available during server-side rendering.
+
+### Prefetching toggles (Next.js)
+
+<!-- Todo: explain what this is and how it works -->
+
+```js
+export async function getServerSideProps() {
+  // Set up unleash to fetch only once in order to not create
+  // bindings for every request (which would cause a memory leak)
+  const unleash = new UnleashClient({
+    ...config, // whatever the rest of your configuration is
+    fetch, // use a custom fetch implementation
+    storageProvider: new InMemoryStorageProvider(), // use a custom in-memory storage provider
+    disableMetrics: true, // don't send metrics
+    disableRefresh: true // don't refresh
+  });
+
+  // optionally update context
+  unleash.updateContext({ userId: '123' });
+
+  // await start to make sure the toggles have been fetched
+  await unleash.start();
+
+  // get all toggles
+  const toggles = unleash.getAllToggles();
+
+
+  return {
+    props: {
+      toggles,
+    },
+  };
+}
+```
+
+And then
+
+```js
+// sample config
+const config = {
+  url: 'https://app.unleash-hosted.com/demo/proxy',
+  clientKey: 'proxy-123',
+  appName: 'ssr',
+  projectName: 'default',
+  refreshInterval: 1000,
+  environment: 'dev',
+};
+
+function MyApp({ Component, pageProps }) {
+  // override fetch and storageProvider when `window` is `'undefined'`
+  const ssrOption = typeof window !== "undefined"
+    ? {}
+    : { fetch: fetch, storageProvider: new InMemoryStorageProvider() };
+
+  const client = new UnleashClient({
+    ...config,
+    ...ssrOption,
+    bootstrap: pageProps.toggles,
+  });
+//
+
+  return (
+    <FlagProvider unleashClient={client}>
+      <Component {...pageProps} />
+    </FlagProvider>
+  );
+}
+```


### PR DESCRIPTION
## What

This PR adds a description to the readme for how to use the client with SSR and Next.js

## Why

We do get question about this fairly often, and while we've been saying for a long time that we want to make it easier to use the client with SSR, we haven't actually done that yet. So for now, I suggest adding this to the readme (as suggested in [this issue comment (#50)](https://github.com/Unleash/proxy-client-react/issues/50#issuecomment-1225274676))

## How

By adding a separate "SSR" subsection to the "Usage section" that uses information from #40 and #50 to explain how to use it and its current drawbacks.

## Author's request

I haven't actually used Next.js myself so I'm a bit shaky when it comes to how everything works and what options we have. I'd love some input and some help co-authoring this bit.