### PR TITLE
3.3.1-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy-client-react",
-  "version": "3.3.1-beta.1",
+  "version": "3.3.1-beta.2",
   "description": "React interface for working with unleash",
   "main": "./dist/index.js",
   "browser": "./dist/index.browser.js",

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -43,7 +43,7 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
     const shouldStartClient = startClient || !unleashClient;
     if (shouldStartClient) {
       // defensively stop the client first
-      client.current?.stop();
+      client.current.stop();
       // start the client
       client.current.start();
     }
@@ -52,7 +52,6 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
     return function cleanup() {
       if (client.current) {
         client.current.stop();
-        client.current = undefined;
       }
     };
   }, []);


### PR DESCRIPTION
I don't think we should set the ref as undefined like in https://github.com/Unleash/proxy-client-react/pull/81, otherwise this breaks in `development`.

Relevant: https://beta.reactjs.org/learn/synchronizing-with-effects#how-to-handle-the-effect-firing-twice-in-development