### PR TITLE
Fix: useFlagsStatus initialization nextjs dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ const MyComponent = ({ userId }) => {
     updateContext({ userId });
   }, [userId]);
 
+  // OR if you need to perform an action right after new context is applied
   useEffect(() => {
     async function run() {
       // Can wait for the new flags to pull in from the different context
@@ -268,8 +269,8 @@ const config = {
 };
 ```
 
-
 # Migration guide
+
 ## Upgrade path from v1 -> v2
 
 If you were previously using the built in Async storage used in the unleash-proxy-client-js, this no longer comes bundled with the library. You will need to install the storage adapter for your preferred storage solution. Otherwise there are no breaking changes.

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "ts-loader": "^9.1.1",
     "ts-node": "^10.2.1",
     "typescript": "^4.4.3",
-    "unleash-proxy-client": "^2.4.1",
+    "unleash-proxy-client": "^2.4.2",
     "webpack": "^5.35.1",
     "webpack-cli": "^4.6.0"
   },
   "peerDependencies": {
-    "unleash-proxy-client": "^2.4.1"
+    "unleash-proxy-client": "^2.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "ts-loader": "^9.1.1",
     "ts-node": "^10.2.1",
     "typescript": "^4.4.3",
-    "unleash-proxy-client": "^2.4.0",
+    "unleash-proxy-client": "^2.4.1",
     "webpack": "^5.35.1",
     "webpack-cli": "^4.6.0"
   },
   "peerDependencies": {
-    "unleash-proxy-client": "^2.4.0"
+    "unleash-proxy-client": "^2.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy-client-react",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "React interface for working with unleash",
   "main": "./dist/index.js",
   "browser": "./dist/index.browser.js",

--- a/src/FlagProvider.test.tsx
+++ b/src/FlagProvider.test.tsx
@@ -59,10 +59,12 @@ const FlagConsumerAfterClientInit = () => {
   const { updateContext, isEnabled, getVariant, client, on } =
     useContext(FlagContext);
   const [enabled, setIsEnabled] = useState(false);
-  const [variant, setVariant] = useState<UnleashClientModule.IVariant>(null);
+  const [variant, setVariant] = useState<UnleashClientModule.IVariant | null>(
+    null
+  );
   const [context, setContext] = useState<any>('nothing');
   const [currentOn, setCurrentOn] =
-    useState<UnleashClientModule.UnleashClient>(null);
+    useState<UnleashClientModule.UnleashClient | null>(null);
 
   useEffect(() => {
     if (client) {
@@ -87,10 +89,12 @@ const FlagConsumerBeforeClientInit = () => {
   const { updateContext, isEnabled, getVariant, client, on } =
     useContext(FlagContext);
   const [enabled, setIsEnabled] = useState(false);
-  const [variant, setVariant] = useState<UnleashClientModule.IVariant>(null);
+  const [variant, setVariant] = useState<UnleashClientModule.IVariant | null>(
+    null
+  );
   const [context, setContext] = useState<any>('nothing');
   const [currentOn, setCurrentOn] =
-    useState<UnleashClientModule.UnleashClient>(null);
+    useState<UnleashClientModule.UnleashClient | null>(null);
 
   useEffect(() => {
     if (!client) {

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -10,13 +10,24 @@ export interface IFlagProvider {
   startClient?: boolean;
 }
 
+const offlineConfig = {
+  bootstrap: [],
+  disableRefresh: true,
+  disableMetrics: true,
+  url: 'http://localhost',
+  appName: 'offline',
+  clientKey: 'not-used',
+};
+
 const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
   config,
   children,
   unleashClient,
   startClient = true,
 }) => {
-  const client = React.useRef<UnleashClient| null>(null);
+  const client = React.useRef<UnleashClient>(
+    unleashClient || new UnleashClient(config || offlineConfig)
+  );
   const [flagsReady, setFlagsReady] = React.useState(false);
   const [flagsError, setFlagsError] = React.useState(null);
   const flagsErrorRef = React.useRef(null);
@@ -28,10 +39,6 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
         If you are initializing the client in useEffect, you can avoid this warning
         by checking if the client exists before rendering.`
       );
-    }
-
-    if (!client.current) {
-      client.current = unleashClient || new UnleashClient(config);
     }
 
     const errorCallback = (e: any) => {

--- a/src/integration.test.tsx
+++ b/src/integration.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { EVENTS, UnleashClient } from 'unleash-proxy-client';
+import '@testing-library/jest-dom';
+
+import FlagProvider from './FlagProvider';
+import useFlagsStatus from './useFlagsStatus';
+import { act } from 'react-dom/test-utils';
+import useFlag from './useFlag';
+import useVariant from './useVariant';
+
+test('should render toggles', async () => {
+  const fetchMock = jest.fn(() => {
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      headers: new Headers({}),
+      json: () => {
+        return Promise.resolve({
+          toggles: [
+            {
+              name: 'test-flag',
+              enabled: true,
+              variant: {
+                name: 'A',
+                payload: { type: 'string', value: 'A' },
+                enabled: true,
+              },
+            },
+          ],
+        });
+      },
+    });
+  });
+
+  const client = new UnleashClient({
+    url: 'http://localhost:4242/api/frontend',
+    appName: 'test',
+    clientKey: 'test',
+    fetch: fetchMock,
+  });
+
+  const TestComponent = () => {
+    const { flagsReady } = useFlagsStatus();
+    const state = useFlag('test-flag');
+    const variant = useVariant('test-flag');
+
+    return (
+      <>
+        <div data-testid="ready">{flagsReady.toString()}</div>
+        <div data-testid="state">{state.toString()}</div>
+        <div data-testid="variant">{JSON.stringify(variant)}</div>
+      </>
+    );
+  };
+
+  const ui = (
+    <FlagProvider unleashClient={client}>
+      <TestComponent />
+    </FlagProvider>
+  );
+
+  const { rerender } = render(ui);
+
+  // Before client initialization
+  expect(fetchMock).not.toHaveBeenCalled();
+  expect(screen.getByTestId('ready')).toHaveTextContent('false');
+  expect(screen.getByTestId('state')).toHaveTextContent('false');
+  expect(screen.getByTestId('variant')).toHaveTextContent('false');
+
+  // Wait for client initialization
+  await act(
+    () =>
+      new Promise((resolve) => {
+        client.on(EVENTS.READY, resolve);
+      })
+  );
+
+  // After client initialization
+  expect(fetchMock).toHaveBeenCalled();
+  rerender(ui);
+  expect(screen.getByTestId('ready')).toHaveTextContent('true');
+  expect(screen.getByTestId('state')).toHaveTextContent('true');
+  expect(screen.getByTestId('variant')).toHaveTextContent(
+    '{"name":"A","payload":{"type":"string","value":"A"},"enabled":true}'
+  );
+});

--- a/src/useVariant.ts
+++ b/src/useVariant.ts
@@ -6,7 +6,10 @@ const useVariant = (name: string): Partial<IVariant> => {
   const { getVariant, client } = useContext(FlagContext);
 
   const [variant, setVariant] = useState(getVariant(name));
-  const variantRef = useRef<typeof variant>();
+  const variantRef = useRef<typeof variant>({
+    name: variant.name,
+    enabled: variant.enabled,
+  });
   variantRef.current = variant;
 
   useEffect(() => {
@@ -15,8 +18,8 @@ const useVariant = (name: string): Partial<IVariant> => {
     const updateHandler = () => {
       const newVariant = getVariant(name);
       if (
-        variantRef.current.name !== newVariant.name ||
-        variantRef.current.enabled !== newVariant.enabled
+        variantRef.current.name !== newVariant?.name ||
+        variantRef.current.enabled !== newVariant?.enabled
       ) {
         setVariant(newVariant);
         variantRef.current = newVariant;
@@ -25,8 +28,8 @@ const useVariant = (name: string): Partial<IVariant> => {
 
     const readyHandler = () => {
       const variant = getVariant(name);
-      variantRef.current.name = variant.name;
-      variantRef.current.enabled = variant.enabled;
+      variantRef.current.name = variant?.name;
+      variantRef.current.enabled = variant?.enabled;
       setVariant(variant);
     };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./dist/",
+    "strict": true,
     "noImplicitAny": true,
     "module": "es6",
     "target": "es5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3938,10 +3938,10 @@ universalify@^0.1.2:
   resolved "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
-unleash-proxy-client@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-2.4.1.tgz#bcdfc09a3ee5337b760a0a50263f61ae66031668"
-  integrity sha512-8ghE36Y9lvFaHPLYe6f7pgXe9p4TVl9vN3YMA5aI1tv5ODbo+yEodxkgAYArFTJgK9N1B11xDMZiqzYeDv2zHg==
+unleash-proxy-client@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-2.4.2.tgz#f83e59f4b46c446f7e98951acecaf7f9016e3cf5"
+  integrity sha512-fkVne/51EsllGFuNFbEidSjB7uErFOI1GJgv9RyXy3LWrBSxIdH/P2lE/keKeH0SrU89/Wufamfk5jLogJTisQ==
   dependencies:
     tiny-emitter "^2.1.0"
     uuid "^8.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3938,10 +3938,10 @@ universalify@^0.1.2:
   resolved "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
-unleash-proxy-client@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-2.4.0.tgz#3b97061bb79ef78f8fe98f3be40dfcb1e1343ac4"
-  integrity sha512-+kvO50Q/hFzrUIecIno9SLaDaKEadX6lOL4cd7kzLG54YqGHii97zEhkqJa1443DJ7oXsj7HjRWXlPycQjpNaQ==
+unleash-proxy-client@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-2.4.1.tgz#bcdfc09a3ee5337b760a0a50263f61ae66031668"
+  integrity sha512-8ghE36Y9lvFaHPLYe6f7pgXe9p4TVl9vN3YMA5aI1tv5ODbo+yEodxkgAYArFTJgK9N1B11xDMZiqzYeDv2zHg==
   dependencies:
     tiny-emitter "^2.1.0"
     uuid "^8.3.2"


### PR DESCRIPTION
## About the changes
Closes [#98 `useFlagsStatus` always returns `false` for `flagsReady`](https://github.com/Unleash/proxy-client-react/issues/98)

Makes #100 obsolete.

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
`FlagProvider.tsx`

