### PR TITLE
fix: make sure flagsReady doesn't go before isEnabled

### DIFF
--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -28,7 +28,9 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
   const client = React.useRef<UnleashClient>(
     unleashClient || new UnleashClient(config || offlineConfig)
   );
-  const [flagsReady, setFlagsReady] = React.useState(false);
+  const [flagsReady, setFlagsReady] = React.useState(
+    client.current.bootstrapped
+  );
   const [flagsError, setFlagsError] = React.useState(null);
   const flagsErrorRef = React.useRef(null);
 
@@ -49,8 +51,13 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
         setFlagsError(e);
       }
     };
+
+    let timeout: any;
     const readyCallback = () => {
-      setFlagsReady(true);
+      // wait for flags to resolve after useFlag gets the same event
+      timeout = setTimeout(() => {
+        setFlagsReady(true);
+      }, 10);
     };
 
     client.current.on('ready', readyCallback);
@@ -70,6 +77,9 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
         client.current.off('error', errorCallback);
         client.current.off('ready', readyCallback);
         client.current.stop();
+      }
+      if (timeout) {
+        clearTimeout(timeout);
       }
     };
   }, []);

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -10,7 +10,7 @@ export interface IFlagProvider {
   startClient?: boolean;
 }
 
-const offlineConfig = {
+const offlineConfig: IConfig = {
   bootstrap: [],
   disableRefresh: true,
   disableMetrics: true,
@@ -20,16 +20,21 @@ const offlineConfig = {
 };
 
 const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
-  config,
+  config: customConfig,
   children,
   unleashClient,
   startClient = true,
 }) => {
+  const config = customConfig || offlineConfig;
   const client = React.useRef<UnleashClient>(
-    unleashClient || new UnleashClient(config || offlineConfig)
+    unleashClient || new UnleashClient(config)
   );
   const [flagsReady, setFlagsReady] = React.useState(
-    client.current.bootstrapped
+    Boolean(
+      unleashClient
+        ? customConfig?.bootstrap && customConfig?.bootstrapOverride !== false
+        : config.bootstrap && config.bootstrapOverride !== false
+    )
   );
   const [flagsError, setFlagsError] = React.useState(null);
   const flagsErrorRef = React.useRef(null);
@@ -57,7 +62,7 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
       // wait for flags to resolve after useFlag gets the same event
       timeout = setTimeout(() => {
         setFlagsReady(true);
-      }, 10);
+      }, 0);
     };
 
     client.current.on('ready', readyCallback);


### PR DESCRIPTION
https://unleash-community.slack.com/archives/C03GWTN7XMG/p1675847730447999

> I can not figure out why useFlag is being updated not at same rate as flagsReadyStatus?
> I mean, my feature flag is on, but when flagsReady is true, it appears to be false, but after a while true
> How can I fix this issue? 