### PR TITLE
Remove event listeners on unmount in useFlag and useVariant

### DIFF
--- a/src/useFlag.ts
+++ b/src/useFlag.ts
@@ -27,7 +27,7 @@ const useFlag = (name: string) => {
     client.on('update', updateHandler);
     client.on('ready', readyHandler);
 
-    () => {
+    return () => {
       client.off('update', updateHandler);
       client.off('ready', readyHandler);
     };

--- a/src/useVariant.ts
+++ b/src/useVariant.ts
@@ -36,7 +36,7 @@ const useVariant = (name: string): Partial<IVariant> => {
     client.on('update', updateHandler);
     client.on('ready', readyHandler);
 
-    () => {
+    return () => {
       client.off('update', updateHandler);
       client.off('ready', readyHandler);
     };


### PR DESCRIPTION
## About the changes
I discovered that the event listeners are not removed properly in useFlag and useVariant. The original author's intention was correct but a return statement were missing by a mistake. It can cause "Can't perform a React state update on an unmounted component." error and unallocated resources.

Closes #90

### Important files
I wrote tests first to prove the error so you should start the review with the new tests. The fix is simple, I've just added the missing returns in the implementation.

### Discussion points
In the test suites I moved the mockClear calls inside the beforeEach, I think it's better to call them before every tests.