### PR TITLE
Fix ref issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist
 yarn-error.log
 /coverage
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy-client-react",
-  "version": "3.5.3-beta.0",
+  "version": "3.6.0",
   "description": "React interface for working with unleash",
   "main": "./dist/index.js",
   "browser": "./dist/index.browser.js",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "webpack-cli": "^4.6.0"
   },
   "peerDependencies": {
-    "unleash-proxy-client": "^2.4.3"
+    "unleash-proxy-client": "^2.5.0"
   }
 }

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -49,11 +49,10 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
     }
 
     const errorCallback = (e: any) => {
-      // Use a ref because regular event handlers are closing over state with stale values:
-      flagsErrorRef.current = e;
-
       if (flagsErrorRef.current === null) {
         setFlagsError(e);
+        // Use a ref because regular event handlers are closing over state with stale values:
+        flagsErrorRef.current = e;
       }
     };
 


### PR DESCRIPTION
Hey ! Submitting a small fix in order to have Context up to date regarding the errors emitted by the JS proxy client.

`setError` vas never called because of the ref value defined before the following check.

Intent is to fix the `v3.6.0` tag. Please check [this commit](https://github.com/Unleash/proxy-client-react/pull/127/commits/fa39d2b71bcccb72b4538aeecf984e5a173f16d2)