### PR TITLE
fix: react to feature_enabled changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",
     "typescript": "^5.2.2",
-    "unleash-proxy-client": "^3.0.0",
+    "unleash-proxy-client": "^3.2.0",
     "vite": "^4.4.11",
     "vite-plugin-dts": "^3.6.0",
     "vitest": "^0.32.4"

--- a/src/integration.test.tsx
+++ b/src/integration.test.tsx
@@ -83,7 +83,7 @@ test('should render toggles', async () => {
   expect(screen.getByTestId('ready')).toHaveTextContent('true');
   expect(screen.getByTestId('state')).toHaveTextContent('true');
   expect(screen.getByTestId('variant')).toHaveTextContent(
-    '{"name":"A","payload":{"type":"string","value":"A"},"enabled":true}'
+    '{"name":"A","payload":{"type":"string","value":"A"},"enabled":true,"feature_enabled":true}'
   );
 });
 

--- a/src/useVariant.ts
+++ b/src/useVariant.ts
@@ -9,6 +9,7 @@ export const variantHasChanged = (
     const variantsAreEqual =
         oldVariant.name === newVariant?.name &&
         oldVariant.enabled === newVariant?.enabled &&
+        oldVariant.feature_enabled === newVariant?.feature_enabled &&
         oldVariant.payload?.type === newVariant?.payload?.type &&
         oldVariant.payload?.value === newVariant?.payload?.value;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2077,10 +2077,10 @@ universalify@^0.2.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
   integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
 
-unleash-proxy-client@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.0.0.tgz#7daa25bcd8c449de43cbccc3bdf0145a1b83bed0"
-  integrity sha512-o9/UOTtvqpa0M3wPwd2YctMqRNO8ID32VCZHAhToJ+3Lh6Qdn1FUqrvyeQpycW/xKuqQNsYXH7W83qSy9Bb/UA==
+unleash-proxy-client@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.2.0.tgz#cdecf1b3bdd40fbe7a20fd66c27906b33e53c4fd"
+  integrity sha512-y9iCRCytxQCej6HlXecGu63ul1Wz6xklXOs+vuaPbqtj4NDGT6IThUvP3h7m5pW+IIxR99hnkVS1FICt1FT3yQ==
   dependencies:
     tiny-emitter "^2.1.0"
     uuid "^9.0.1"


### PR DESCRIPTION
Fixes an issue where `useVariant` would not listen to changes in the `feature_enabled` property.

Should we bump the `unleash-proxy-client` peer dependency?