### PR TITLE
chore: bump proxy-client peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "vitest": "^0.32.4"
   },
   "peerDependencies": {
-    "unleash-proxy-client": "^3.0.0"
+    "unleash-proxy-client": "^3.2.0"
   }
 }


### PR DESCRIPTION
Bumps `unleash-proxy-client` peer dependency to `^3.2.0`.