### PR TITLE
fix: fallback for startTransition for React <18

### DIFF
--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -19,6 +19,11 @@ const offlineConfig: IConfig = {
   clientKey: 'not-used',
 };
 
+// save startTransition as var to avoid webpack analysis (https://github.com/webpack/webpack/issues/14814)
+const _startTransition = 'startTransition';
+// fallback for React <18 which doesn't support startTransition
+const startTransition = React[_startTransition] || (fn => fn());
+
 const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
   config: customConfig,
   children,
@@ -48,7 +53,7 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
     }
 
     const errorCallback = (e: any) => {
-      React.startTransition(() => {
+      startTransition(() => {
         setFlagsError(currentError => currentError || e);
       });
     };
@@ -57,7 +62,7 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
     const readyCallback = () => {
       // wait for flags to resolve after useFlag gets the same event
       timeout = setTimeout(() => {
-        React.startTransition(() => {
+        startTransition(() => {
           setFlagsReady(true);
         });
       }, 0);


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
Fallback when `startTransition` isn't supported, notably in React <18.

<!-- Does it close an issue? Multiple? -->
Closes #151

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
I did have to do something a little hacky to trip up webpack's export analysis. I originally tried the `.toString()` version that's suggested in the linked webpack issue but that made the typescript inference break.

I wasn't sure how to write tests but I did test this across 2 repos, one with React 16 and one with React 17 and it seems to work fine.
