### PR TITLE
fix: clear stale errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",
     "typescript": "^5.3.2",
-    "unleash-proxy-client": "^3.2.0",
+    "unleash-proxy-client": "^3.3.0-beta.1",
     "vite": "^4.5.0",
     "vite-plugin-dts": "^3.6.3",
     "vitest": "^0.34.6"

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -58,6 +58,12 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
       });
     };
 
+    const clearErrorCallback = (e: any) => {
+      startTransition(() => {
+        setFlagsError(null);
+      });
+    } 
+
     let timeout: any;
     const readyCallback = () => {
       // wait for flags to resolve after useFlag gets the same event
@@ -70,6 +76,7 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
 
     client.current.on('ready', readyCallback);
     client.current.on('error', errorCallback);
+    client.current.on('recovered', clearErrorCallback);
 
     const shouldStartClient = startClient || !unleashClient;
     if (shouldStartClient) {
@@ -84,6 +91,7 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
       if (client.current) {
         client.current.off('error', errorCallback);
         client.current.off('ready', readyCallback);
+        client.current.off('recovered', clearErrorCallback)
         client.current.stop();
       }
       if (timeout) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1910,10 +1910,10 @@ universalify@^0.2.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
   integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
 
-unleash-proxy-client@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.2.0.tgz#cdecf1b3bdd40fbe7a20fd66c27906b33e53c4fd"
-  integrity sha512-y9iCRCytxQCej6HlXecGu63ul1Wz6xklXOs+vuaPbqtj4NDGT6IThUvP3h7m5pW+IIxR99hnkVS1FICt1FT3yQ==
+unleash-proxy-client@^3.3.0-beta.1:
+  version "3.3.0-beta.1"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.3.0-beta.1.tgz#c13f89472af8c992df56295d1b6913c52237dff5"
+  integrity sha512-Vswscc9+zZyEL0lAtzCvMG2zgu9krbsr6WxWnmk9FEMBHjyz++P3bD8Rtsv3fU1TRheESmjXQk6+a3g8nWRxFw==
   dependencies:
     tiny-emitter "^2.1.0"
     uuid "^9.0.1"


### PR DESCRIPTION
This PR fixes a bug where errors would not be cleared out and kept in state.

**How**

In the parent SDK we emit a 'recovered' event when the network call is successful following an errored HTTP call. In this SDK we listen to the recover event and set the error state to `null`.