### PR TITLE
docs: rename parameters related to feature name

### DIFF
--- a/src/useFlag.ts
+++ b/src/useFlag.ts
@@ -1,9 +1,9 @@
 import { useContext, useEffect, useState, useRef } from 'react';
 import FlagContext from './FlagContext';
 
-const useFlag = (name: string) => {
+const useFlag = (featureName: string) => {
   const { isEnabled, client } = useContext(FlagContext);
-  const [flag, setFlag] = useState(!!isEnabled(name));
+  const [flag, setFlag] = useState(!!isEnabled(featureName));
   const flagRef = useRef<typeof flag>();
   flagRef.current = flag;
 
@@ -11,7 +11,7 @@ const useFlag = (name: string) => {
     if (!client) return;
 
     const updateHandler = () => {
-      const enabled = isEnabled(name);
+      const enabled = isEnabled(featureName);
       if (enabled !== flagRef.current) {
         flagRef.current = enabled;
         setFlag(!!enabled);
@@ -19,7 +19,7 @@ const useFlag = (name: string) => {
     };
 
     const readyHandler = () => {
-      const enabled = isEnabled(name);
+      const enabled = isEnabled(featureName);
       flagRef.current = enabled;
       setFlag(enabled);
     };

--- a/src/useVariant.ts
+++ b/src/useVariant.ts
@@ -16,10 +16,10 @@ export const variantHasChanged = (
     return !variantsAreEqual;
 };
 
-const useVariant = (name: string): Partial<IVariant> => {
+const useVariant = (featureName: string): Partial<IVariant> => {
   const { getVariant, client } = useContext(FlagContext);
 
-  const [variant, setVariant] = useState(getVariant(name));
+  const [variant, setVariant] = useState(getVariant(featureName));
   const variantRef = useRef<typeof variant>({
     name: variant.name,
     enabled: variant.enabled,
@@ -30,7 +30,7 @@ const useVariant = (name: string): Partial<IVariant> => {
     if (!client) return;
 
     const updateHandler = () => {
-      const newVariant = getVariant(name);
+      const newVariant = getVariant(featureName);
       if (variantHasChanged(variantRef.current, newVariant)) {
         setVariant(newVariant);
         variantRef.current = newVariant;
@@ -38,7 +38,7 @@ const useVariant = (name: string): Partial<IVariant> => {
     };
 
     const readyHandler = () => {
-      const variant = getVariant(name);
+      const variant = getVariant(featureName);
       variantRef.current.name = variant?.name;
       variantRef.current.enabled = variant?.enabled;
       setVariant(variant);


### PR DESCRIPTION
Make it more intuitive what is an expected parameter for `useFlag` and `useVariant`.