### PR TITLE
fix: allow start client to be used for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,6 @@ Deferring the client start gives you more fine-grained control over when to star
 To start the client, use the client's `start` method. The below snippet of pseudocode will defer polling until the end of the `asyncProcess` function.
 
 ```jsx
-const client = new UnleashClient({
-  /* ... */
-});
 
 const MyAppComponent = () => {
   useEffect(() => {
@@ -298,7 +295,7 @@ Upgrading should be as easy as running yarn again with the new version, but we m
 
 ## Upgrade path from v3 -> v4
 
-`startClient` option has been simpilfied. Now it will also work if you don't pass custom client with it, and in SSR (when `typeof window === 'undefined'`) it defaults to `false`.
+`startClient` option has been simplified. Now it will also work if you don't pass custom client with it. It defaults to `true`.
 
 #### Note on v4.0.0:
 The major release is driven by Node14 end of life and represents no other changes.  From this version onwards we do not guarantee that this library will work server side with Node 14.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ Deferring the client start gives you more fine-grained control over when to star
 To start the client, use the client's `start` method. The below snippet of pseudocode will defer polling until the end of the `asyncProcess` function.
 
 ```jsx
+const client = new UnleashClient({
+  /* ... */
+});
 
 const MyAppComponent = () => {
   useEffect(() => {

--- a/src/FlagProvider.test.tsx
+++ b/src/FlagProvider.test.tsx
@@ -271,3 +271,27 @@ test('should not start client if startClient is false', () => {
   expect(localMock).not.toHaveBeenCalled();
   expect(stopMock).not.toHaveBeenCalled();
 });
+
+test('should not start client if startClient is false when passing config', () => {
+  const localMock = vi.fn();
+  const stopMock = vi.fn();
+  UnleashClientSpy.mockReturnValue({
+    getVariant: getVariantMock,
+    updateContext: updateContextMock,
+    start: localMock,
+    stop: stopMock,
+    isEnabled: isEnabledMock,
+    on: onMock,
+    off: offMock,
+  });
+
+
+  render(
+    <FlagProvider config={givenConfig} startClient={false}>
+      <div>Hi</div>
+    </FlagProvider>
+  );
+
+  expect(localMock).not.toHaveBeenCalled();
+  expect(stopMock).not.toHaveBeenCalled();
+});

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -64,7 +64,7 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
       });
     } 
 
-    let timeout: any; 
+    let timeout: any;
     const readyCallback = () => {
       // wait for flags to resolve after useFlag gets the same event
       timeout = setTimeout(() => {

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -64,7 +64,7 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
       });
     } 
 
-    let timeout: any;
+    let timeout: any; 
     const readyCallback = () => {
       // wait for flags to resolve after useFlag gets the same event
       timeout = setTimeout(() => {
@@ -78,8 +78,7 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
     client.current.on('error', errorCallback);
     client.current.on('recovered', clearErrorCallback);
 
-    const shouldStartClient = startClient || !unleashClient;
-    if (shouldStartClient) {
+    if (startClient) {
       // defensively stop the client first
       client.current.stop();
       // start the client


### PR DESCRIPTION
This PR will allow the `startClient` option to be used even if you pass in a config. This change should be backwards compatible as the startClient option is defaulted to `true`. We consider it a bug that startClient does not work when you pass in the config option. 

Solves #161 