### PR TITLE
fix: provider initialization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: 📌 Install
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: 🔨 Build
         run: yarn build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 21.x, 22.x]
+        node-version: [18.x, 20.x, 21.x]
     steps:
       - uses: actions/checkout@v2
 
@@ -22,7 +22,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: 📌 Install
-        run: yarn install --frozen-lockfile
+        run: yarn
 
       - name: 🔨 Build
         run: yarn build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 21.x]
+        node-version: [18.x, 20.x, 21.x, 22.x]
     steps:
       - uses: actions/checkout@v2
 

--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
     "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",
     "typescript": "^5.3.2",
-    "unleash-proxy-client": "^3.4.0",
+    "unleash-proxy-client": "^3.5.0",
     "vite": "^4.5.0",
     "vite-plugin-dts": "^3.6.3",
     "vitest": "^0.34.6"
   },
   "peerDependencies": {
-    "unleash-proxy-client": "^3.4.0"
+    "unleash-proxy-client": "^3.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
     "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",
     "typescript": "^5.3.2",
-    "unleash-proxy-client": "^3.5.0",
+    "unleash-proxy-client": "^3.5.1",
     "vite": "^4.5.0",
     "vite-plugin-dts": "^3.6.3",
     "vitest": "^0.34.6"
   },
   "peerDependencies": {
-    "unleash-proxy-client": "^3.5.0"
+    "unleash-proxy-client": "^3.5.1"
   }
 }

--- a/src/FlagContext.ts
+++ b/src/FlagContext.ts
@@ -4,7 +4,7 @@ import type { UnleashClient } from 'unleash-proxy-client';
 export interface IFlagContextValue
   extends Pick<
     UnleashClient,
-    'on' | 'updateContext' | 'isEnabled' | 'getVariant'
+    'on' | 'off' | 'updateContext' | 'isEnabled' | 'getVariant'
   > {
   client: UnleashClient;
   flagsReady: boolean;

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -39,11 +39,11 @@ const FlagProvider: FC<PropsWithChildren<IFlagProvider>> = ({
   const [flagsReady, setFlagsReady] = React.useState(
     Boolean(
       unleashClient
-        ? (customConfig?.bootstrap && customConfig?.bootstrapOverride !== false) || unleashClient.isReady()
+        ? (customConfig?.bootstrap && customConfig?.bootstrapOverride !== false) || unleashClient.isReady?.()
         : config.bootstrap && config.bootstrapOverride !== false
     )
   );
-  const [flagsError, setFlagsError] = useState(null);
+  const [flagsError, setFlagsError] = useState(client?.getError?.() || null);
 
   useEffect(() => {
     if (!config && !unleashClient) {

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -56,7 +56,7 @@ const FlagProvider: FC<PropsWithChildren<IFlagProvider>> = ({
 
     const errorCallback = (e: any) => {
       startTransition(() => {
-        setFlagsError(currentError => currentError || e);
+        setFlagsError((currentError: any) => currentError || e);
       });
     };
 

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -43,7 +43,7 @@ const FlagProvider: FC<PropsWithChildren<IFlagProvider>> = ({
         : config.bootstrap && config.bootstrapOverride !== false
     )
   );
-  const [flagsError, setFlagsError] = useState(client?.getError?.() || null);
+  const [flagsError, setFlagsError] = useState(client.current.getError?.() || null);
 
   useEffect(() => {
     if (!config && !unleashClient) {

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -29,6 +29,7 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
   children,
   unleashClient,
   startClient = true,
+  stopClient = true,
 }) => {
   const config = customConfig || offlineConfig;
   const client = React.useRef<UnleashClient>(
@@ -90,8 +91,10 @@ const FlagProvider: React.FC<React.PropsWithChildren<IFlagProvider>> = ({
       if (client.current) {
         client.current.off('error', errorCallback);
         client.current.off('ready', readyCallback);
-        client.current.off('recovered', clearErrorCallback)
-        client.current.stop();
+        client.current.off('recovered', clearErrorCallback);
+        if (stopClient) {
+          client.current.stop();
+        }
       }
       if (timeout) {
         clearTimeout(timeout);

--- a/src/useFlagStatus.test.tsx
+++ b/src/useFlagStatus.test.tsx
@@ -1,70 +1,80 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import useFlagsStatus from "./useFlagsStatus";
+import useFlagsStatus from './useFlagsStatus';
 import FlagProvider from './FlagProvider';
-import { EVENTS, type UnleashClient } from 'unleash-proxy-client';
+import { EVENTS, UnleashClient } from 'unleash-proxy-client';
 
 const TestComponent = () => {
-    const { flagsReady } = useFlagsStatus();
+  const { flagsReady } = useFlagsStatus();
 
-    return <div>{flagsReady ? 'flagsReady' : 'loading'}</div>;
-}
+  return <div>{flagsReady ? 'flagsReady' : 'loading'}</div>;
+};
 
 const mockClient = {
-    on: vi.fn(),
-    off: vi.fn(),
-    start: vi.fn(),
-    stop: vi.fn(),
-    updateContext: vi.fn(),
-    isEnabled: vi.fn(),
-    getVariant: vi.fn(),
+  on: vi.fn(),
+  off: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+  updateContext: vi.fn(),
+  isEnabled: vi.fn(),
+  getVariant: vi.fn(),
+  isReady: vi.fn(),
 } as unknown as UnleashClient;
 
 test('should initialize', async () => {
-    const onEventHandler = (event: string, callback: () => void) => {
-        if (event === 'ready') {
-            callback();
-        }
+  const onEventHandler = (event: string, callback: () => void) => {
+    if (event === 'ready') {
+      callback();
     }
+  };
 
-    mockClient.on = onEventHandler as typeof mockClient.on;
+  mockClient.on = onEventHandler as typeof mockClient.on;
 
-    const ui = (
-        <FlagProvider unleashClient={mockClient}>
-            <TestComponent />
-        </FlagProvider>
-    )
+  const ui = (
+    <FlagProvider unleashClient={mockClient}>
+      <TestComponent />
+    </FlagProvider>
+  );
 
-    render(ui);
+  render(ui);
 
-    await waitFor(() => {
-        expect(screen.queryByText('flagsReady')).toBeInTheDocument();
-    });
+  await waitFor(() => {
+    expect(screen.queryByText('flagsReady')).toBeInTheDocument();
+  });
 });
 
 // https://github.com/Unleash/proxy-client-react/issues/168
 test('should start when already initialized client is passed', async () => {
-    let initialized = false;
-    const onEventHandler = (event: string, callback: () => void) => {
-        if (event === EVENTS.READY && !initialized) {
-            initialized = true;
-            callback();
-        }
-    }
+  const client = new UnleashClient({
+    url: 'http://localhost:4242/api',
+    fetch: async () =>
+      new Promise((resolve) => {
+        setTimeout(() =>
+          resolve({
+            status: 200,
+            ok: true,
+            json: async () => ({
+              toggles: [],
+            }),
+            headers: new Headers(),
+          })
+        );
+      }),
+    clientKey: '123',
+    appName: 'test',
+  });
+  await client.start();
+  expect(client.isReady()).toBe(true);
 
-    mockClient.on = onEventHandler as typeof mockClient.on;
+  const ui = (
+    <FlagProvider unleashClient={client}>
+      <TestComponent />
+    </FlagProvider>
+  );
 
-    await new Promise((resolve) => mockClient.on(EVENTS.READY, () => resolve));
+  render(ui);
 
-    const ui = (
-        <FlagProvider unleashClient={mockClient}>
-            <TestComponent />
-        </FlagProvider>
-    )
-
-    render(ui);
-
-    await waitFor(() => {
-        expect(screen.queryByText('flagsReady')).toBeInTheDocument();
-    });
+  await waitFor(() => {
+    expect(screen.queryByText('flagsReady')).toBeInTheDocument();
+  });
 });

--- a/src/useFlagStatus.test.tsx
+++ b/src/useFlagStatus.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import useFlagsStatus from "./useFlagsStatus";
+import FlagProvider from './FlagProvider';
+import { EVENTS, type UnleashClient } from 'unleash-proxy-client';
+
+const TestComponent = () => {
+    const { flagsReady } = useFlagsStatus();
+
+    return <div>{flagsReady ? 'flagsReady' : 'loading'}</div>;
+}
+
+const mockClient = {
+    on: vi.fn(),
+    off: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+    updateContext: vi.fn(),
+    isEnabled: vi.fn(),
+    getVariant: vi.fn(),
+} as unknown as UnleashClient;
+
+test('should initialize', async () => {
+    const onEventHandler = (event: string, callback: () => void) => {
+        if (event === 'ready') {
+            callback();
+        }
+    }
+
+    mockClient.on = onEventHandler as typeof mockClient.on;
+
+    const ui = (
+        <FlagProvider unleashClient={mockClient}>
+            <TestComponent />
+        </FlagProvider>
+    )
+
+    render(ui);
+
+    await waitFor(() => {
+        expect(screen.queryByText('flagsReady')).toBeInTheDocument();
+    });
+});
+
+// https://github.com/Unleash/proxy-client-react/issues/168
+test('should start when already initialized client is passed', async () => {
+    let initialized = false;
+    const onEventHandler = (event: string, callback: () => void) => {
+        if (event === EVENTS.READY && !initialized) {
+            initialized = true;
+            callback();
+        }
+    }
+
+    mockClient.on = onEventHandler as typeof mockClient.on;
+
+    await new Promise((resolve) => mockClient.on(EVENTS.READY, () => resolve));
+
+    const ui = (
+        <FlagProvider unleashClient={mockClient}>
+            <TestComponent />
+        </FlagProvider>
+    )
+
+    render(ui);
+
+    await waitFor(() => {
+        expect(screen.queryByText('flagsReady')).toBeInTheDocument();
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1972,10 +1972,10 @@ universalify@^0.2.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
   integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
 
-unleash-proxy-client@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.4.0.tgz#c9c4a8b0f18d77dc0b041eb76478c6ce74c98c1e"
-  integrity sha512-ivCzm//z+S2T3gSBSZY7HN+5GfoLXZIovMyH6lIZRe2/vCicEdXtXD6cnLTQ2LAiXGV7DpoSM1m8WZGoiLRzkw==
+unleash-proxy-client@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.5.0.tgz#52ef4bc96c6c2bae445f6704c457584d4d3e4549"
+  integrity sha512-/LXs6+uvht/6/pO3pEdxW0n4yft8e+Ngw3/4z63f49gjTb0FE8rZvSosQcBajBiiCivpFx6eXAAoCcREGVCSJg==
   dependencies:
     tiny-emitter "^2.1.0"
     uuid "^9.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1972,10 +1972,10 @@ universalify@^0.2.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
   integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
 
-unleash-proxy-client@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.5.0.tgz#52ef4bc96c6c2bae445f6704c457584d4d3e4549"
-  integrity sha512-/LXs6+uvht/6/pO3pEdxW0n4yft8e+Ngw3/4z63f49gjTb0FE8rZvSosQcBajBiiCivpFx6eXAAoCcREGVCSJg==
+unleash-proxy-client@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.5.1.tgz#603af23b4c30e3509b8123e7a9ae99a9c38f335d"
+  integrity sha512-vfWAozp5O16ZedPPH7wFobsZaj8TQQEp/pfj+4jpWZTnOXyFpH6fAgrztRHO26bQ6iC95vVtfeVRQvgw9lo5zA==
   dependencies:
     tiny-emitter "^2.1.0"
     uuid "^9.0.1"


### PR DESCRIPTION
There was a bug where the flagsReady status, returned from the useFlagsStatus hook, remains false even when an already started Unleash client is passed to the Unleash flag provider. This occurred despite the client being initialized and ready.

Closes #168 

## About the changes
- [x] test showing the issue
- [x] externalizing SDK state
  - [x] Upgrade unleash-proxy-client dependency to version 3.5.1.
- [x] check state in Provider
  - [x] Updated the initialization logic to check if the client is already ready and set flagsReady appropriately.