### PR TITLE
fix: async not transpiled on babel for older browser

### DIFF
--- a/src/FlagProvider.test.tsx
+++ b/src/FlagProvider.test.tsx
@@ -110,7 +110,7 @@ test('A consumer that subscribes AFTER client init shows values from provider an
     'consuming value isEnabled true'
   );
   expect(screen.getByText(/consuming value updateContext/)).toHaveTextContent(
-    'consuming value updateContext [object Promise]'
+    'consuming value updateContext undefined'
   );
   expect(screen.getByText(/consuming value getVariant/)).toHaveTextContent(
     'consuming value getVariant A'
@@ -148,7 +148,7 @@ test('A consumer should be able to get a variant when the client is passed into 
     'consuming value isEnabled true'
   );
   expect(screen.getByText(/consuming value updateContext/)).toHaveTextContent(
-    'consuming value updateContext [object Promise]'
+    'consuming value updateContext undefined'
   );
   expect(screen.getByText(/consuming value getVariant/)).toHaveTextContent(
     'consuming value getVariant A'

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -107,7 +107,7 @@ const FlagProvider: FC<PropsWithChildren<IFlagProvider>> = ({
     () => ({
       on: ((event, callback, ctx) => client.current.on(event, callback, ctx)) as IFlagContextValue['on'],
       off: ((event, callback) => client.current.off(event, callback)) as IFlagContextValue['off'],
-      updateContext: (context) => client.current.updateContext(context),
+      updateContext: client.current.updateContext,
       isEnabled: (toggleName) => client.current.isEnabled(toggleName),
       getVariant: (toggleName) => client.current.getVariant(toggleName),
       client: client.current,

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -107,7 +107,7 @@ const FlagProvider: FC<PropsWithChildren<IFlagProvider>> = ({
     () => ({
       on: ((event, callback, ctx) => client.current.on(event, callback, ctx)) as IFlagContextValue['on'],
       off: ((event, callback) => client.current.off(event, callback)) as IFlagContextValue['off'],
-      updateContext: async (context) => await client.current.updateContext(context),
+      updateContext: (context) => client.current.updateContext(context),
       isEnabled: (toggleName) => client.current.isEnabled(toggleName),
       getVariant: (toggleName) => client.current.getVariant(toggleName),
       client: client.current,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
- old browser (chrome v50) gets error from the async await
- despite attempt to transpile with babel-plugin-transform-async-to-generator, it still not transpiled on my compiler
- solution is to update the codebase, since there is no value to return, might as well directly return the method result if it's a Promise

<!-- Does it close an issue? Multiple? -->
Closes #173 

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
Technically if [updateContext](https://github.com/Unleash/unleash-proxy-client-js/blob/a1a0e03862a633bc37e9dcfbcbe5fab0cd4547b8/src/index.ts#L341) have nothing to return, then we don't need to use `async` as well to wrap the function here. CMIIW.