### PR TITLE
fix: avoid startTransition in React Native

### DIFF
--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -23,7 +23,11 @@ const offlineConfig: IConfig = {
 // save startTransition as var to avoid webpack analysis (https://github.com/webpack/webpack/issues/14814)
 const _startTransition = 'startTransition';
 // fallback for React <18 which doesn't support startTransition
-const startTransition = React[_startTransition] || (fn => fn());
+const isReactNative = typeof navigator !== 'undefined' && navigator?.product === 'ReactNative';
+// Fallback for React <18 and exclude startTransition if in React Native
+const startTransition: (fn: () => void) => void = !isReactNative && React[_startTransition]
+  ? React[_startTransition]
+  : (fn => fn());
 
 const FlagProvider: FC<PropsWithChildren<IFlagProvider>> = ({
   config: customConfig,

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -9,6 +9,7 @@ export interface IFlagProvider {
   unleashClient?: UnleashClient;
   startClient?: boolean;
   stopClient?: boolean;
+  startTransition?: (fn: () => void) => void;
 }
 
 const offlineConfig: IConfig = {
@@ -23,9 +24,8 @@ const offlineConfig: IConfig = {
 // save startTransition as var to avoid webpack analysis (https://github.com/webpack/webpack/issues/14814)
 const _startTransition = 'startTransition';
 // fallback for React <18 which doesn't support startTransition
-const isReactNative = typeof navigator !== 'undefined' && navigator?.product === 'ReactNative';
 // Fallback for React <18 and exclude startTransition if in React Native
-const startTransition: (fn: () => void) => void = !isReactNative && React[_startTransition]
+const defaultStartTransition: (fn: () => void) => void = React[_startTransition]
   ? React[_startTransition]
   : (fn => fn());
 
@@ -35,6 +35,7 @@ const FlagProvider: FC<PropsWithChildren<IFlagProvider>> = ({
   unleashClient,
   startClient = true,
   stopClient = true,
+  startTransition = defaultStartTransition
 }) => {
   const config = customConfig || offlineConfig;
   const client = React.useRef<UnleashClient>(

--- a/src/FlagProvider.tsx
+++ b/src/FlagProvider.tsx
@@ -25,9 +25,7 @@ const offlineConfig: IConfig = {
 const _startTransition = 'startTransition';
 // fallback for React <18 which doesn't support startTransition
 // Fallback for React <18 and exclude startTransition if in React Native
-const defaultStartTransition: (fn: () => void) => void = React[_startTransition]
-  ? React[_startTransition]
-  : (fn => fn());
+const defaultStartTransition = React[_startTransition] || (fn => fn());
 
 const FlagProvider: FC<PropsWithChildren<IFlagProvider>> = ({
   config: customConfig,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Unleash SDK uses startTransition under the hood. RN 0.75 and 0.76 (latest) break on startTransition (https://github.com/facebook/react-native/pull/44586). React itself removed internal _callbacks set on the transition (https://github.com/acdlite/react/commit/12a387d95e81a9507ade8fb796ded27615188c2f) while RN still has it.

This PR performs feature detection to find if the code is running in RN and skips startTransition in a similar way as we do for older React versions.

Ideally this PR should not be needed but until RN supports the new startTransition we may need to have this fallback.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
