### PR TITLE
feat: add sdk uniqueness headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",
     "typescript": "^5.3.2",
-    "unleash-proxy-client": "^3.5.2",
+    "unleash-proxy-client": "^3.7.0",
     "vite": "^4.5.0",
     "vite-plugin-dts": "^3.6.3",
     "vitest": "^0.34.6"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",
     "typescript": "^5.3.2",
-    "unleash-proxy-client": "^3.7.0",
+    "unleash-proxy-client": "^3.7.1",
     "vite": "^4.5.0",
     "vite-plugin-dts": "^3.6.3",
     "vitest": "^0.34.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1972,10 +1972,10 @@ universalify@^0.2.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
   integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
 
-unleash-proxy-client@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.7.0.tgz#d9c116875c19f0ee2207973c7b9111705611f945"
-  integrity sha512-SkgVnu7xz2PSwyKvM3SUJXPvtokJZvDrUGp6utYSxwHa5DFrn3FUnCnLpAUjV8tzF+GenPcsm9DAHS1drs5GyQ==
+unleash-proxy-client@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.7.1.tgz#c51483aebaad664e6d6ea70828f5f10bece61a40"
+  integrity sha512-ri3cauGfQBjvRvwwJIQfnHlpOfFvQz0iy5hVd82Tr4t0LkqpqFr248tuO8jkI39JXelUcX7TCGNHneeMMPZM1A==
   dependencies:
     tiny-emitter "^2.1.0"
     uuid "^9.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1972,7 +1972,7 @@ universalify@^0.2.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
   integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
 
-unleash-proxy-client@^3.5.2:
+unleash-proxy-client@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.7.0.tgz#d9c116875c19f0ee2207973c7b9111705611f945"
   integrity sha512-SkgVnu7xz2PSwyKvM3SUJXPvtokJZvDrUGp6utYSxwHa5DFrn3FUnCnLpAUjV8tzF+GenPcsm9DAHS1drs5GyQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1973,9 +1973,9 @@ universalify@^0.2.0:
   integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
 
 unleash-proxy-client@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.5.2.tgz#e5c1735e94ada7abec33958e2b252ba66ad83074"
-  integrity sha512-fbxTmNyJ/B6uKAZSRcfzZ9IXHokPikWgI14/6DQU3poJjZr+P7hX2KyZbkucd1/0VFYWnNTPAn+ihwyV3C8F/Q==
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.7.0.tgz#d9c116875c19f0ee2207973c7b9111705611f945"
+  integrity sha512-SkgVnu7xz2PSwyKvM3SUJXPvtokJZvDrUGp6utYSxwHa5DFrn3FUnCnLpAUjV8tzF+GenPcsm9DAHS1drs5GyQ==
   dependencies:
     tiny-emitter "^2.1.0"
     uuid "^9.0.1"


### PR DESCRIPTION
Updates the dependency on the underlying Unleash client to 3.7.1. This
version of the client adds new `x-unleash` headers which lets Unleash
count unique connections and see SDK version information.