### PR TITLE
Meta: update release template to use npm release v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,11 @@ on:
 
 jobs:
   from-template:
-    uses: Unleash/.github/.github/workflows/npm-release.yml@v1.1.0
+    uses: Unleash/.github/.github/workflows/npm-release.yml@v2.0.0
     with:
       version: ${{ github.event.inputs.version }}
       tag: ${{ github.event.inputs.tag }}
     secrets:
-      GH_ACCESS_TOKEN: ${{ secrets.GH_TOKEN}}
       NPM_ACCESS_TOKEN: ${{ secrets.NPM_TOKEN }}
+      UNLEASH_BOT_APP_ID: ${{ secrets.UNLEASH_BOT_APP_ID }}
+      UNLEASH_BOT_PRIVATE_KEY: ${{ secrets.UNLEASH_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Updates the release template to use the new npm release v2 action, which relies on the GitHub bot instead of a personal PAT.