### PR TITLE
chore: remove dev dependency on proxy client

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",
     "typescript": "^5.3.2",
-    "unleash-proxy-client": "^3.7.2",
     "vite": "^4.5.0",
     "vite-plugin-dts": "^3.6.3",
     "vitest": "^0.34.6"


### PR DESCRIPTION
Removes the dev dependency on the proxy client, leaving it only as a peer dependency. There is no reason to have both dependencies, and it's probably and oversight that we do.
