### PR TITLE
fix: console.error

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Upgrading should be as easy as running yarn again with the new version, but we m
 
 ## Upgrade path from v4 -> v5
 
-[FlagContext public interface changed](https://github.com/Unleash/proxy-client-react/commit/b783ef4016dbb881ac3d878cffaf5241b047cc35#diff-825c82ad66c3934257e0ee3e0511d9223db22e7ddf5de9cbdf6485206e3e02cfL20-R20). if you used FlagContext directly you may have to adjust your types.
+[FlagContext public interface changed](https://github.com/Unleash/proxy-client-react/commit/b783ef4016dbb881ac3d878cffaf5241b047cc35#diff-825c82ad66c3934257e0ee3e0511d9223db22e7ddf5de9cbdf6485206e3e02cfL20-R20). If you used FlagContext directly you may have to adjust your code slightly to accomodate the new type changes.
 
 
 #### Note on v4.0.0:

--- a/README.md
+++ b/README.md
@@ -345,6 +345,11 @@ Upgrading should be as easy as running yarn again with the new version, but we m
 
 `startClient` option has been simplified. Now it will also work if you don't pass custom client with it. It defaults to `true`.
 
+## Upgrade path from v4 -> v5
+
+[FlagContext public interface changed](https://github.com/Unleash/proxy-client-react/commit/b783ef4016dbb881ac3d878cffaf5241b047cc35#diff-825c82ad66c3934257e0ee3e0511d9223db22e7ddf5de9cbdf6485206e3e02cfL20-R20). if you used FlagContext directly you may have to adjust your types.
+
+
 #### Note on v4.0.0:
 The major release is driven by Node14 end of life and represents no other changes.  From this version onwards we do not guarantee that this library will work server side with Node 14.
 

--- a/src/useFlagContext.test.ts
+++ b/src/useFlagContext.test.ts
@@ -1,17 +1,24 @@
-import { renderHook } from '@testing-library/react-hooks/native';
+import { renderHook } from '@testing-library/react';
+import { vi, test, expect } from 'vitest';
 import FlagProvider from "./FlagProvider";
 import { useFlagContext } from "./useFlagContext";
 
-test("throws an error if used outside of a FlagProvider", () => {
-    const { result } = renderHook(() => useFlagContext());
+test("logs an error if used outside of a FlagProvider", () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     
-    expect(result.error).toEqual(
-        Error("This hook must be used within a FlagProvider")
-    );
+    const { result } = renderHook(() => useFlagContext());
+    expect(consoleSpy).toHaveBeenCalledWith("This hook must be used within a FlagProvider");
+    expect(result.current).toBeNull();
+    
+    consoleSpy.mockRestore();
 });
 
-test("does not throw an error if used inside of a FlagProvider", () => {
-    const { result } = renderHook(() => useFlagContext(), { wrapper: FlagProvider });
+test("does not log an error if used inside of a FlagProvider", () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     
-    expect(result.error).toBeUndefined();
+    const { result } = renderHook(() => useFlagContext(), { wrapper: FlagProvider });
+    expect(consoleSpy).not.toHaveBeenCalled();
+    expect(result.current).not.toBeNull();
+    
+    consoleSpy.mockRestore();
 });

--- a/src/useFlagContext.test.ts
+++ b/src/useFlagContext.test.ts
@@ -7,7 +7,7 @@ test("logs an error if used outside of a FlagProvider", () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     
     renderHook(() => useFlagContext());
-    expect(consoleSpy).toHaveBeenCalledWith("useFlagContext hook must be used within a FlagProvider");
+    expect(consoleSpy).toHaveBeenCalledWith("useFlagContext() must be used within a FlagProvider");
     
     consoleSpy.mockRestore();
 });

--- a/src/useFlagContext.test.ts
+++ b/src/useFlagContext.test.ts
@@ -7,8 +7,7 @@ test("logs an error if used outside of a FlagProvider", () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     
     renderHook(() => useFlagContext());
-    
-    expect(consoleSpy).toHaveBeenCalledWith("This hook must be used within a FlagProvider");
+    expect(consoleSpy).toHaveBeenCalledWith("useFlagContext hook must be used within a FlagProvider");
     
     consoleSpy.mockRestore();
 });

--- a/src/useFlagContext.test.ts
+++ b/src/useFlagContext.test.ts
@@ -6,9 +6,9 @@ import { useFlagContext } from "./useFlagContext";
 test("logs an error if used outside of a FlagProvider", () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     
-    const { result } = renderHook(() => useFlagContext());
+    renderHook(() => useFlagContext());
+    
     expect(consoleSpy).toHaveBeenCalledWith("This hook must be used within a FlagProvider");
-    expect(result.current).toBeNull();
     
     consoleSpy.mockRestore();
 });
@@ -17,6 +17,7 @@ test("does not log an error if used inside of a FlagProvider", () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     
     const { result } = renderHook(() => useFlagContext(), { wrapper: FlagProvider });
+    
     expect(consoleSpy).not.toHaveBeenCalled();
     expect(result.current).not.toBeNull();
     

--- a/src/useFlagContext.ts
+++ b/src/useFlagContext.ts
@@ -1,11 +1,75 @@
 import { useContext } from 'react';
-import FlagContext from './FlagContext';
+import FlagContext, { IFlagContextValue } from './FlagContext';
+import { UnleashClient } from 'unleash-proxy-client';
+
+const noopOn = (event: string, callback: Function, ctx?: any): UnleashClient => {
+  console.error('This hook must be used within a FlagProvider');
+  return mockUnleashClient;
+};
+
+const noopOff = (event: string, callback?: Function): UnleashClient => {
+  console.error('This hook must be used within a FlagProvider');
+  return mockUnleashClient;
+};
+
+const mockUnleashClient = {
+  on: noopOn,
+  off: noopOff,
+  updateContext: async () => {
+    console.error('This hook must be used within a FlagProvider');
+    return undefined;
+  },
+  isEnabled: () => {
+    console.error('This hook must be used within a FlagProvider');
+    return false;
+  },
+  getVariant: () => {
+    console.error('This hook must be used within a FlagProvider');
+    return { name: 'disabled', enabled: false };
+  },
+  toggles: [],
+  impressionDataAll: {},
+  context: {},
+  storage: {},
+  start: () => {},
+  stop: () => {},
+  isReady: () => false,
+  getError: () => null,
+  getAllToggles: () => [],
+} as unknown as UnleashClient;
+
+// Create a default context value
+const defaultContextValue: IFlagContextValue = {
+  on: noopOn,
+  off: noopOff,
+  updateContext: async () => {
+    console.error('updateContext hook must be used within a FlagProvider');
+    return undefined;
+  },
+  isEnabled: () => {
+    console.error('isEnabled hook must be used within a FlagProvider');
+    return false;
+  },
+  getVariant: () => {
+    console.error('getVariant hook must be used within a FlagProvider');
+    return { name: 'disabled', enabled: false };
+  },
+  client: mockUnleashClient,
+  flagsReady: false,
+  setFlagsReady: () => {
+    console.error('setFlagsReady hook must be used within a FlagProvider');
+  },
+  flagsError: null,
+  setFlagsError: () => {
+    console.error('setFlagsError hook must be used within a FlagProvider');
+  }
+};
 
 export function useFlagContext() {
-    const context = useContext(FlagContext);
-    if (!context) {
-      console.error('This hook must be used within a FlagProvider');
-      return null;
-    }
-    return context;
+  const context = useContext(FlagContext);
+  if (!context) {
+    console.error('useFlagContext hook must be used within a FlagProvider');
+    return defaultContextValue;
+  }
+  return context;
 }

--- a/src/useFlagContext.ts
+++ b/src/useFlagContext.ts
@@ -1,75 +1,61 @@
-import { useContext } from 'react';
-import FlagContext, { IFlagContextValue } from './FlagContext';
-import { UnleashClient } from 'unleash-proxy-client';
+import { useContext } from "react";
+import FlagContext, { type IFlagContextValue } from "./FlagContext";
+import type { UnleashClient } from "unleash-proxy-client";
 
-const noopOn = (event: string, callback: Function, ctx?: any): UnleashClient => {
-  console.error('This hook must be used within a FlagProvider');
-  return mockUnleashClient;
-};
-
-const noopOff = (event: string, callback?: Function): UnleashClient => {
-  console.error('This hook must be used within a FlagProvider');
-  return mockUnleashClient;
+const methods = {
+	on: (event: string, callback: Function, ctx?: any): UnleashClient => {
+		console.error("on() must be used within a FlagProvider");
+		return mockUnleashClient;
+	},
+	off: (event: string, callback?: Function): UnleashClient => {
+		console.error("off() must be used within a FlagProvider");
+		return mockUnleashClient;
+	},
+	updateContext: async () => {
+		console.error("updateContext() must be used within a FlagProvider");
+		return undefined;
+	},
+	isEnabled: () => {
+		console.error("isEnabled() must be used within a FlagProvider");
+		return false;
+	},
+	getVariant: () => {
+		console.error("getVariant() must be used within a FlagProvider");
+		return { name: "disabled", enabled: false };
+	}
 };
 
 const mockUnleashClient = {
-  on: noopOn,
-  off: noopOff,
-  updateContext: async () => {
-    console.error('This hook must be used within a FlagProvider');
-    return undefined;
-  },
-  isEnabled: () => {
-    console.error('This hook must be used within a FlagProvider');
-    return false;
-  },
-  getVariant: () => {
-    console.error('This hook must be used within a FlagProvider');
-    return { name: 'disabled', enabled: false };
-  },
-  toggles: [],
-  impressionDataAll: {},
-  context: {},
-  storage: {},
-  start: () => {},
-  stop: () => {},
-  isReady: () => false,
-  getError: () => null,
-  getAllToggles: () => [],
+	...methods,
+	toggles: [],
+	impressionDataAll: {},
+	context: {},
+	storage: {},
+	start: () => {},
+	stop: () => {},
+	isReady: () => false,
+	getError: () => null,
+	getAllToggles: () => []
 } as unknown as UnleashClient;
 
-// Create a default context value
 const defaultContextValue: IFlagContextValue = {
-  on: noopOn,
-  off: noopOff,
-  updateContext: async () => {
-    console.error('updateContext hook must be used within a FlagProvider');
-    return undefined;
-  },
-  isEnabled: () => {
-    console.error('isEnabled hook must be used within a FlagProvider');
-    return false;
-  },
-  getVariant: () => {
-    console.error('getVariant hook must be used within a FlagProvider');
-    return { name: 'disabled', enabled: false };
-  },
-  client: mockUnleashClient,
-  flagsReady: false,
-  setFlagsReady: () => {
-    console.error('setFlagsReady hook must be used within a FlagProvider');
-  },
-  flagsError: null,
-  setFlagsError: () => {
-    console.error('setFlagsError hook must be used within a FlagProvider');
-  }
+	...methods,
+	client: mockUnleashClient,
+	flagsReady: false,
+	setFlagsReady: () => {
+		console.error("setFlagsReady() must be used within a FlagProvider");
+	},
+	flagsError: null,
+	setFlagsError: () => {
+		console.error("setFlagsError() must be used within a FlagProvider");
+	}
 };
 
 export function useFlagContext() {
-  const context = useContext(FlagContext);
-  if (!context) {
-    console.error('useFlagContext hook must be used within a FlagProvider');
-    return defaultContextValue;
-  }
-  return context;
+	const context = useContext(FlagContext);
+	if (!context) {
+		console.error("useFlagContext() must be used within a FlagProvider");
+		return defaultContextValue;
+	}
+	return context;
 }

--- a/src/useFlagContext.ts
+++ b/src/useFlagContext.ts
@@ -4,7 +4,8 @@ import FlagContext from './FlagContext';
 export function useFlagContext() {
     const context = useContext(FlagContext);
     if (!context) {
-      throw new Error('This hook must be used within a FlagProvider');
+      console.error('This hook must be used within a FlagProvider');
+      return null;
     }
     return context;
 }


### PR DESCRIPTION
Instead of throwing if the context is not provided, we'll console.error the message instead.