### PR TITLE
chore: remove uuid from lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,11 +1522,6 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-uuid@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
-
 "vite@^6.0.0 || ^7.0.0 || ^8.0.0", vite@^8.0.3:
   version "8.0.16"
   resolved "https://registry.yarnpkg.com/vite/-/vite-8.0.16.tgz#ae073866c06563d6634a90169a496e11bd84f1a6"


### PR DESCRIPTION
It's not used or required by anything, so let's just try to remove it.