### PR TITLE
fix: return correct flag/variant values with useSyncExternalStore

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,16 @@
   ],
   "author": "",
   "license": "Apache-2.0",
+  "dependencies": {
+    "use-sync-external-store": "^1.6.0"
+  },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
+    "@types/use-sync-external-store": "^1.5.0",
     "@vitest/coverage-v8": "^4.1.2",
     "@vitest/ui": "^4.1.2",
     "jsdom": "^23.0.0",

--- a/src/integration.test.tsx
+++ b/src/integration.test.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { EVENTS, UnleashClient } from 'unleash-proxy-client';
+import { EVENTS, IToggle, UnleashClient } from 'unleash-proxy-client';
 import FlagProvider from './FlagProvider';
 import useFlagsStatus from './useFlagsStatus';
 import { act } from 'react-dom/test-utils';
 import useFlag from './useFlag';
 import { useFlagContext } from './useFlagContext';
 import useVariant from './useVariant';
+import useFlags from './useFlags';
 
 const fetchMock = vi.fn(async () => {
   return Promise.resolve({
@@ -261,4 +262,206 @@ test('should resolve values before setting flagsReady', async () => {
     expect(screen.queryByText('enabled')).toBeInTheDocument();
     expect(renders).toBe(3);
   });
+});
+
+test('should update useFlag when ready/update fires between render and effect', () => {
+  const client = createFakeClient();
+
+  const Component = () => {
+    const enabled = useFlag('test-flag');
+
+    return <div data-testid="state">{enabled.toString()}</div>;
+  };
+
+  render(
+    <FlagProvider
+      unleashClient={client as unknown as UnleashClient}
+      startClient={false}
+    >
+      <ResolveFetchDuringCommit client={client} />
+      <Component />
+    </FlagProvider>
+  );
+
+  expect(screen.getByTestId('state')).toHaveTextContent('true');
+});
+
+test('should update useVariant when ready/update fires between render and effect', () => {
+  const client = createFakeClient();
+
+  const Component = () => {
+    const variant = useVariant('test-flag');
+
+    return <div data-testid="variant">{variant.name}</div>;
+  };
+
+  render(
+    <FlagProvider
+      unleashClient={client as unknown as UnleashClient}
+      startClient={false}
+    >
+      <ResolveFetchDuringCommit client={client} />
+      <Component />
+    </FlagProvider>
+  );
+
+  expect(screen.getByTestId('variant')).toHaveTextContent('A');
+});
+
+type FakeClient = Pick<
+  UnleashClient,
+  | 'isEnabled'
+  | 'getVariant'
+  | 'getAllToggles'
+  | 'updateContext'
+  | 'start'
+  | 'stop'
+  | 'isReady'
+  | 'getError'
+> & {
+  // On the real client, these methods return `this`.
+  // It is hard to simulate in this fake client, so we return `void` instead.
+  on: (event: string, callback: () => void) => void;
+  off: (event: string, callback: () => void) => void;
+  // Test-only: allows us to simulate the client's first fetch resolving.
+  resolveFirstFetch: () => void;
+};
+
+const testToggle: IToggle = {
+  name: 'test-flag',
+  enabled: true,
+  variant: {
+    name: 'A',
+    enabled: true,
+    feature_enabled: true,
+    payload: { type: 'string', value: 'A' },
+  },
+  impressionData: false,
+};
+
+const createEventEmitter = () => {
+  const callbacks: Record<string, Array<() => void>> = {};
+
+  return {
+    on(event: string, callback: () => void) {
+      const current = callbacks[event] ?? [];
+      callbacks[event] = [...current, callback];
+    },
+    off(event: string, callback: () => void) {
+      const current = callbacks[event] ?? [];
+      callbacks[event] = current.filter((cb) => cb !== callback);
+    },
+    emit(event: string) {
+      const current = callbacks[event] ?? [];
+      current.forEach((callback) => callback());
+    },
+  };
+};
+
+const createFakeClient = (): FakeClient => {
+  const events = createEventEmitter();
+  let toggles: IToggle[] = [];
+
+  return {
+    on: events.on,
+    off: events.off,
+    isEnabled: (name) => Boolean(toggles.find((t) => t.name === name)?.enabled),
+    getVariant: (name) =>
+      toggles.find((t) => t.name === name)?.variant ?? {
+        name: 'disabled',
+        enabled: false,
+      },
+    getAllToggles: () => toggles,
+    updateContext: async () => {},
+    start: async () => {},
+    stop: () => {},
+    isReady: () => false,
+    getError: () => null,
+    resolveFirstFetch: () => {
+      // Set the toggles before emitting, so a listener that re-reads flag state
+      // while handling the event sees them — the same order the real client uses.
+      toggles = [testToggle];
+      events.emit('update');
+      events.emit('ready');
+    },
+  };
+};
+
+// Fires "first fetch resolved" from a layout effect, so the client emits
+// ready/update after the hook has rendered but before its passive effect
+// subscribes — the exact render-vs-effect gap that triggers the bug.
+const ResolveFetchDuringCommit = ({ client }: { client: FakeClient }) => {
+  useLayoutEffect(() => {
+    client.resolveFirstFetch();
+  }, [client]);
+  return null;
+};
+
+test('should update useFlags when update fires between render and effect', () => {
+  const client = createFakeClient();
+
+  const Component = () => {
+    const flags = useFlags();
+
+    return <div data-testid="count">{flags.length.toString()}</div>;
+  };
+
+  render(
+    <FlagProvider
+      unleashClient={client as unknown as UnleashClient}
+      startClient={false}
+    >
+      <ResolveFetchDuringCommit client={client} />
+      <Component />
+    </FlagProvider>
+  );
+
+  // The toggle arrived before the hook subscribed, so it must re-read to reach a
+  // count of 1 rather than stay on its empty initial list.
+  expect(screen.getByTestId('count')).toHaveTextContent('1');
+});
+
+test('should update useFlag when the featureName argument changes', () => {
+  const client = new UnleashClient({
+    url: 'http://localhost:4242/api/frontend',
+    appName: 'test',
+    clientKey: 'test',
+    fetch: fetchMock,
+    bootstrap: [
+      {
+        name: 'enabled-flag',
+        enabled: true,
+        variant: {
+          name: 'A',
+          enabled: true,
+          payload: { type: 'string', value: 'A' },
+        },
+        impressionData: false,
+      },
+    ],
+  });
+
+  const Component = ({ name }: { name: string }) => {
+    const enabled = useFlag(name);
+
+    return <div data-testid="state">{enabled.toString()}</div>;
+  };
+
+  const { rerender } = render(
+    <FlagProvider unleashClient={client} startClient={false}>
+      <Component name="enabled-flag" />
+    </FlagProvider>
+  );
+  expect(screen.getByTestId('state')).toHaveTextContent('true');
+
+  // The prop now points at a different flag that is disabled.
+  rerender(
+    <FlagProvider unleashClient={client} startClient={false}>
+      <Component name="some-other-flag" />
+    </FlagProvider>
+  );
+
+  // Pointing the hook at a different, disabled flag must flip it to `false`
+  // rather than keep showing the previous flag's `true`.
+  expect(screen.getByTestId('state')).toHaveTextContent('false');
 });

--- a/src/integration.test.tsx
+++ b/src/integration.test.tsx
@@ -1,6 +1,7 @@
 import React, { useLayoutEffect } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { EVENTS, IToggle, UnleashClient } from 'unleash-proxy-client';
+import { EVENTS, UnleashClient } from 'unleash-proxy-client';
+import type { IToggle } from 'unleash-proxy-client';
 import FlagProvider from './FlagProvider';
 import useFlagsStatus from './useFlagsStatus';
 import { act } from 'react-dom/test-utils';

--- a/src/integration.test.tsx
+++ b/src/integration.test.tsx
@@ -264,50 +264,6 @@ test('should resolve values before setting flagsReady', async () => {
   });
 });
 
-test('should update useFlag when ready/update fires between render and effect', () => {
-  const client = createFakeClient();
-
-  const Component = () => {
-    const enabled = useFlag('test-flag');
-
-    return <div data-testid="state">{enabled.toString()}</div>;
-  };
-
-  render(
-    <FlagProvider
-      unleashClient={client as unknown as UnleashClient}
-      startClient={false}
-    >
-      <ResolveFetchDuringCommit client={client} />
-      <Component />
-    </FlagProvider>
-  );
-
-  expect(screen.getByTestId('state')).toHaveTextContent('true');
-});
-
-test('should update useVariant when ready/update fires between render and effect', () => {
-  const client = createFakeClient();
-
-  const Component = () => {
-    const variant = useVariant('test-flag');
-
-    return <div data-testid="variant">{variant.name}</div>;
-  };
-
-  render(
-    <FlagProvider
-      unleashClient={client as unknown as UnleashClient}
-      startClient={false}
-    >
-      <ResolveFetchDuringCommit client={client} />
-      <Component />
-    </FlagProvider>
-  );
-
-  expect(screen.getByTestId('variant')).toHaveTextContent('A');
-});
-
 type FakeClient = Pick<
   UnleashClient,
   | 'isEnabled'
@@ -396,6 +352,50 @@ const ResolveFetchDuringCommit = ({ client }: { client: FakeClient }) => {
   }, [client]);
   return null;
 };
+
+test('should update useFlag when ready/update fires between render and effect', () => {
+  const client = createFakeClient();
+
+  const Component = () => {
+    const enabled = useFlag('test-flag');
+
+    return <div data-testid="state">{enabled.toString()}</div>;
+  };
+
+  render(
+    <FlagProvider
+      unleashClient={client as unknown as UnleashClient}
+      startClient={false}
+    >
+      <ResolveFetchDuringCommit client={client} />
+      <Component />
+    </FlagProvider>
+  );
+
+  expect(screen.getByTestId('state')).toHaveTextContent('true');
+});
+
+test('should update useVariant when ready/update fires between render and effect', () => {
+  const client = createFakeClient();
+
+  const Component = () => {
+    const variant = useVariant('test-flag');
+
+    return <div data-testid="variant">{variant.name}</div>;
+  };
+
+  render(
+    <FlagProvider
+      unleashClient={client as unknown as UnleashClient}
+      startClient={false}
+    >
+      <ResolveFetchDuringCommit client={client} />
+      <Component />
+    </FlagProvider>
+  );
+
+  expect(screen.getByTestId('variant')).toHaveTextContent('A');
+});
 
 test('should update useFlags when update fires between render and effect', () => {
   const client = createFakeClient();

--- a/src/useFlag.test.tsx
+++ b/src/useFlag.test.tsx
@@ -30,7 +30,6 @@ test('should return false when the flag is NOT enabled in context', () => {
   expect(clientMock.on).toHaveBeenCalledWith('update', expect.any(Function));
   expect(clientMock.on).toHaveBeenCalledWith('ready', expect.any(Function));
   expect(result.current).toBe(false);
-  expect(isEnabledMock).toHaveBeenCalledTimes(1);
 });
 
 test('should return true when the flag is enabled in context', () => {
@@ -40,10 +39,9 @@ test('should return true when the flag is enabled in context', () => {
   expect(clientMock.on).toHaveBeenCalledWith('update', expect.any(Function));
   expect(clientMock.on).toHaveBeenCalledWith('ready', expect.any(Function));
   expect(result.current).toBe(true);
-  expect(isEnabledMock).toHaveBeenCalledTimes(1);
 });
 
-test('should return true when the client is ready and re-call isEnabled', () => {
+test('should return true when the client becomes ready', () => {
   isEnabledMock.mockReturnValue(true);
   clientMock.on.mockImplementation((eventName: string, cb: Function) => {
     if (eventName === 'ready') {
@@ -56,12 +54,11 @@ test('should return true when the client is ready and re-call isEnabled', () => 
   expect(clientMock.on).toHaveBeenCalledWith('update', expect.any(Function));
   expect(clientMock.on).toHaveBeenCalledWith('ready', expect.any(Function));
   expect(result.current).toBe(true);
-  expect(isEnabledMock).toHaveBeenCalledTimes(2);
 });
 
 test('should return true when the client is first false and is updated with true', () => {
   isEnabledMock.mockReturnValueOnce(false);
-  isEnabledMock.mockReturnValueOnce(true);
+  isEnabledMock.mockReturnValue(true);
   clientMock.on.mockImplementation((eventName: string, cb: Function) => {
     if (eventName === 'update') {
       cb();
@@ -73,26 +70,28 @@ test('should return true when the client is first false and is updated with true
   expect(result.current).toBe(true);
   expect(clientMock.on).toHaveBeenCalledWith('update', expect.any(Function));
   expect(clientMock.on).toHaveBeenCalledWith('ready', expect.any(Function));
-  expect(isEnabledMock).toHaveBeenCalledTimes(3);
 });
 
-test('should set the local state only once', () => {
-  isEnabledMock.mockReturnValueOnce(true);
-  isEnabledMock.mockReturnValueOnce(true);
+test('should not re-render when an update leaves the value unchanged', () => {
+  isEnabledMock.mockReturnValue(true);
   clientMock.on.mockImplementation((eventName: string, cb: Function) => {
     if (eventName === 'update') {
       cb();
     }
   });
 
-  const { result } = renderHook(() => useFlag(givenFlagName));
+  let renders = 0;
+  const { result } = renderHook(() => {
+    renders += 1;
+    return useFlag(givenFlagName);
+  });
 
   expect(result.current).toBe(true);
-  expect(isEnabledMock).toHaveBeenCalledTimes(2);
+  expect(renders).toBe(1);
 });
 
 test('should NOT subscribe to ready or update if client does NOT exist', () => {
-  isEnabledMock.mockReturnValueOnce(false);
+  isEnabledMock.mockReturnValue(false);
   vi.mocked(useContext).mockImplementationOnce(() => ({
     client: undefined,
     isEnabled: isEnabledMock,
@@ -102,8 +101,6 @@ test('should NOT subscribe to ready or update if client does NOT exist', () => {
 
   expect(result.current).toBe(false);
   expect(clientMock.on).not.toHaveBeenCalled();
-  expect(clientMock.on).not.toHaveBeenCalled();
-  expect(isEnabledMock).toHaveBeenCalledTimes(1);
 });
 
 test('should remove event listeners when unmounted', () => {

--- a/src/useFlag.test.tsx
+++ b/src/useFlag.test.tsx
@@ -115,3 +115,33 @@ test('should remove event listeners when unmounted', () => {
   expect(clientMock.off).nthCalledWith(1, ...clientMock.on.mock.calls[0]);
   expect(clientMock.off).nthCalledWith(2, ...clientMock.on.mock.calls[1]);
 });
+
+test('reconciles the flag when ready/update fired before the effect subscribed', () => {
+  // Seeded false at render, but the client is actually enabled — the one-shot
+  // ready/update already fired, so `on` never invokes the handlers we register.
+  isEnabledMock.mockReturnValueOnce(false);
+  isEnabledMock.mockReturnValue(true);
+  clientMock.on.mockImplementation(() => {});
+
+  const { result } = renderHook(() => useFlag(givenFlagName));
+
+  // A correct hook re-reads once it subscribes and reports `true`. The buggy
+  // version stays stuck on its initial `false`.
+  expect(result.current).toBe(true);
+});
+
+test('re-reads when the featureName argument changes', () => {
+  isEnabledMock.mockImplementation((name: string) => name === 'enabled-flag');
+  clientMock.on.mockImplementation(() => {});
+
+  const { result, rerender } = renderHook(({ name }) => useFlag(name), {
+    initialProps: { name: 'enabled-flag' },
+  });
+  expect(result.current).toBe(true);
+
+  // Pointing the hook at a different, disabled flag should flip it to `false`.
+  // The buggy version keeps the old value because `featureName` is missing from
+  // the effect deps, so it never re-reads.
+  rerender({ name: 'some-other-flag' });
+  expect(result.current).toBe(false);
+});

--- a/src/useFlag.ts
+++ b/src/useFlag.ts
@@ -1,22 +1,11 @@
-import { useCallback } from 'react';
 import { useSyncExternalStore } from 'use-sync-external-store/shim';
 import { useFlagContext } from './useFlagContext';
+import useUnleashClientSubscription from './useUnleashClientSubscription';
 
 const useFlag = (featureName: string): boolean => {
   const { isEnabled, client } = useFlagContext();
 
-  const subscribe = useCallback(
-    (onStoreChange: () => void) => {
-      if (!client) return () => {};
-      client.on('update', onStoreChange);
-      client.on('ready', onStoreChange);
-      return () => {
-        client.off('update', onStoreChange);
-        client.off('ready', onStoreChange);
-      };
-    },
-    [client]
-  );
+  const subscribe = useUnleashClientSubscription(client);
 
   const getSnapshot = () => isEnabled(featureName);
 

--- a/src/useFlag.ts
+++ b/src/useFlag.ts
@@ -5,11 +5,15 @@ import useUnleashClientSubscription from './useUnleashClientSubscription';
 const useFlag = (featureName: string): boolean => {
   const { isEnabled, client } = useFlagContext();
 
-  const subscribe = useUnleashClientSubscription(client);
+  const subscribeToUnleashClient = useUnleashClientSubscription(client);
 
-  const getSnapshot = () => isEnabled(featureName);
+  const getFlagSnapshot = () => isEnabled(featureName);
 
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return useSyncExternalStore(
+    subscribeToUnleashClient,
+    getFlagSnapshot,
+    getFlagSnapshot
+  );
 };
 
 export default useFlag;

--- a/src/useFlag.ts
+++ b/src/useFlag.ts
@@ -1,39 +1,26 @@
-import { useEffect, useState, useRef } from 'react';
+import { useCallback } from 'react';
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
 import { useFlagContext } from './useFlagContext';
 
-const useFlag = (featureName: string) => {
-  const  { isEnabled, client }  = useFlagContext();
-  const [flag, setFlag] = useState(!!isEnabled(featureName));
-  const flagRef = useRef<typeof flag>(flag);
-  flagRef.current = flag;
+const useFlag = (featureName: string): boolean => {
+  const { isEnabled, client } = useFlagContext();
 
-  useEffect(() => {
-    if (!client) return;
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!client) return () => {};
+      client.on('update', onStoreChange);
+      client.on('ready', onStoreChange);
+      return () => {
+        client.off('update', onStoreChange);
+        client.off('ready', onStoreChange);
+      };
+    },
+    [client]
+  );
 
-    const updateHandler = () => {
-      const enabled = isEnabled(featureName);
-      if (enabled !== flagRef.current) {
-        flagRef.current = enabled;
-        setFlag(!!enabled);
-      }
-    };
+  const getSnapshot = () => isEnabled(featureName);
 
-    const readyHandler = () => {
-      const enabled = isEnabled(featureName);
-      flagRef.current = enabled;
-      setFlag(enabled);
-    };
-
-    client.on('update', updateHandler);
-    client.on('ready', readyHandler);
-
-    return () => {
-      client.off('update', updateHandler);
-      client.off('ready', readyHandler);
-    };
-  }, [client]);
-
-  return flag;
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 };
 
 export default useFlag;

--- a/src/useFlags.test.tsx
+++ b/src/useFlags.test.tsx
@@ -1,0 +1,76 @@
+import { vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useContext } from 'react';
+import useFlags from './useFlags';
+
+vi.mock('react', async () => {
+  const react = (await vi.importActual('react')) as any;
+  return {
+    ...react,
+    useContext: vi.fn(react.useContext),
+  };
+});
+
+const getAllTogglesMock = vi.fn();
+const clientMock: any = {
+  on: vi.fn(),
+  off: vi.fn(),
+  getAllToggles: getAllTogglesMock,
+};
+
+beforeEach(() => {
+  getAllTogglesMock.mockClear();
+  clientMock.on.mockClear();
+  clientMock.off.mockClear();
+});
+
+test('returns the toggles the client already has and subscribes for updates', () => {
+  const toggles = [{ name: 'a', enabled: true }];
+  getAllTogglesMock.mockReturnValue(toggles);
+  vi.mocked(useContext).mockReturnValue({ client: clientMock });
+
+  const { result } = renderHook(() => useFlags());
+
+  expect(result.current).toBe(toggles);
+  expect(clientMock.on).toHaveBeenCalledWith('update', expect.any(Function));
+});
+
+test('subscribes to ready so it can recover from a missed first fetch', () => {
+  getAllTogglesMock.mockReturnValue([]);
+  vi.mocked(useContext).mockReturnValue({ client: clientMock });
+
+  renderHook(() => useFlags());
+
+  // Without a `ready` listener the hook can never recover a first fetch it missed,
+  // since `ready` is emitted once and won't repeat.
+  expect(clientMock.on).toHaveBeenCalledWith('ready', expect.any(Function));
+});
+
+test('reconciles toggles that arrived before the effect subscribed', () => {
+  const toggles = [{ name: 'a', enabled: true }];
+  // Empty at render, but the client received its toggles before we subscribed —
+  // the update/ready fired first, so `on` never invokes our handler.
+  getAllTogglesMock.mockReturnValueOnce([]);
+  getAllTogglesMock.mockReturnValue(toggles);
+  vi.mocked(useContext).mockReturnValue({ client: clientMock });
+  clientMock.on.mockImplementation(() => {});
+
+  const { result } = renderHook(() => useFlags());
+
+  // A correct hook re-reads once it subscribes and returns the toggles. The buggy
+  // version stays on its empty initial list.
+  expect(result.current).toBe(toggles);
+});
+
+test('should remove event listeners when unmounted', () => {
+  getAllTogglesMock.mockReturnValue([]);
+  vi.mocked(useContext).mockReturnValue({ client: clientMock });
+
+  const { unmount } = renderHook(() => useFlags());
+
+  unmount();
+
+  clientMock.on.mock.calls.forEach((call: unknown[]) => {
+    expect(clientMock.off).toHaveBeenCalledWith(...call);
+  });
+});

--- a/src/useFlags.test.tsx
+++ b/src/useFlags.test.tsx
@@ -1,5 +1,5 @@
 import { vi } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { useContext } from 'react';
 import useFlags from './useFlags';
 
@@ -60,6 +60,43 @@ test('reconciles toggles that arrived before the effect subscribed', () => {
   // A correct hook re-reads once it subscribes and returns the toggles. The buggy
   // version stays on its empty initial list.
   expect(result.current).toBe(toggles);
+});
+
+test('does not re-render when an update yields equivalent toggles', () => {
+  getAllTogglesMock.mockImplementation(() => [
+    {
+      name: 'a',
+      enabled: true,
+      variant: { name: 'A', enabled: true },
+    },
+  ]);
+  vi.mocked(useContext).mockReturnValue({ client: clientMock });
+
+  let onUpdate: () => void = () => {};
+  clientMock.on.mockImplementation(
+    (eventName: string, callback: () => void) => {
+      if (eventName === 'update') {
+        onUpdate = callback;
+      }
+    }
+  );
+
+  let renders = 0;
+  const { result } = renderHook(() => {
+    renders += 1;
+    return useFlags();
+  });
+
+  act(() => onUpdate());
+
+  expect(result.current).toEqual([
+    {
+      name: 'a',
+      enabled: true,
+      variant: { name: 'A', enabled: true },
+    },
+  ]);
+  expect(renders).toBe(1);
 });
 
 test('should remove event listeners when unmounted', () => {

--- a/src/useFlags.ts
+++ b/src/useFlags.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
 import { IToggle } from 'unleash-proxy-client';
 import { useFlagContext } from './useFlagContext';
+import useUnleashClientSubscription from './useUnleashClientSubscription';
 
 const togglesAreEqual = (a: IToggle[], b: IToggle[]): boolean =>
   a.length === b.length &&
@@ -22,18 +23,7 @@ const togglesAreEqual = (a: IToggle[], b: IToggle[]): boolean =>
 const useFlags = (): IToggle[] => {
   const { client } = useFlagContext();
 
-  const subscribe = useCallback(
-    (onStoreChange: () => void) => {
-      if (!client) return () => {};
-      client.on('update', onStoreChange);
-      client.on('ready', onStoreChange);
-      return () => {
-        client.off('update', onStoreChange);
-        client.off('ready', onStoreChange);
-      };
-    },
-    [client]
-  );
+  const subscribe = useUnleashClientSubscription(client);
 
   const getSnapshot = useCallback(
     () => client?.getAllToggles() ?? [],

--- a/src/useFlags.ts
+++ b/src/useFlags.ts
@@ -1,23 +1,52 @@
-import { useEffect, useState } from 'react';
+import { useCallback } from 'react';
+import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
+import { IToggle } from 'unleash-proxy-client';
 import { useFlagContext } from './useFlagContext';
 
-const useFlags = () => {
+const togglesAreEqual = (a: IToggle[], b: IToggle[]): boolean =>
+  a.length === b.length &&
+  a.every((toggle, index) => {
+    const other = b[index];
+    return (
+      Boolean(other) &&
+      toggle.name === other.name &&
+      toggle.enabled === other.enabled &&
+      toggle.variant?.name === other.variant?.name &&
+      toggle.variant?.enabled === other.variant?.enabled &&
+      toggle.variant?.feature_enabled === other.variant?.feature_enabled &&
+      toggle.variant?.payload?.type === other.variant?.payload?.type &&
+      toggle.variant?.payload?.value === other.variant?.payload?.value
+    );
+  });
+
+const useFlags = (): IToggle[] => {
   const { client } = useFlagContext();
-  const [flags, setFlags] = useState(client.getAllToggles());
 
-  useEffect(() => {
-    const onUpdate = () => {
-      setFlags(client.getAllToggles());
-    };
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!client) return () => {};
+      client.on('update', onStoreChange);
+      client.on('ready', onStoreChange);
+      return () => {
+        client.off('update', onStoreChange);
+        client.off('ready', onStoreChange);
+      };
+    },
+    [client]
+  );
 
-    client.on('update', onUpdate);
+  const getSnapshot = useCallback(
+    () => client?.getAllToggles() ?? [],
+    [client]
+  );
 
-    return () => {
-      client.off('update', onUpdate);
-    };
-  }, []);
-
-  return flags;
+  return useSyncExternalStoreWithSelector(
+    subscribe,
+    getSnapshot,
+    getSnapshot,
+    (toggles) => toggles,
+    togglesAreEqual
+  );
 };
 
 export default useFlags;

--- a/src/useFlags.ts
+++ b/src/useFlags.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
-import { IToggle } from 'unleash-proxy-client';
+import type { IToggle } from 'unleash-proxy-client';
 import { useFlagContext } from './useFlagContext';
 import useUnleashClientSubscription from './useUnleashClientSubscription';
 import variantsAreEqual from './variantsAreEqual';

--- a/src/useFlags.ts
+++ b/src/useFlags.ts
@@ -17,21 +17,23 @@ const togglesAreEqual = (a: IToggle[], b: IToggle[]): boolean =>
     );
   });
 
+const selectToggles = (toggles: IToggle[]) => toggles;
+
 const useFlags = (): IToggle[] => {
   const { client } = useFlagContext();
 
-  const subscribe = useUnleashClientSubscription(client);
+  const subscribeToUnleashClient = useUnleashClientSubscription(client);
 
-  const getSnapshot = useCallback(
+  const getTogglesSnapshot = useCallback(
     () => client?.getAllToggles() ?? [],
     [client]
   );
 
   return useSyncExternalStoreWithSelector(
-    subscribe,
-    getSnapshot,
-    getSnapshot,
-    (toggles) => toggles,
+    subscribeToUnleashClient,
+    getTogglesSnapshot,
+    getTogglesSnapshot,
+    selectToggles,
     togglesAreEqual
   );
 };

--- a/src/useFlags.ts
+++ b/src/useFlags.ts
@@ -3,6 +3,7 @@ import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/w
 import { IToggle } from 'unleash-proxy-client';
 import { useFlagContext } from './useFlagContext';
 import useUnleashClientSubscription from './useUnleashClientSubscription';
+import variantsAreEqual from './variantsAreEqual';
 
 const togglesAreEqual = (a: IToggle[], b: IToggle[]): boolean =>
   a.length === b.length &&
@@ -12,11 +13,7 @@ const togglesAreEqual = (a: IToggle[], b: IToggle[]): boolean =>
       Boolean(other) &&
       toggle.name === other.name &&
       toggle.enabled === other.enabled &&
-      toggle.variant?.name === other.variant?.name &&
-      toggle.variant?.enabled === other.variant?.enabled &&
-      toggle.variant?.feature_enabled === other.variant?.feature_enabled &&
-      toggle.variant?.payload?.type === other.variant?.payload?.type &&
-      toggle.variant?.payload?.value === other.variant?.payload?.value
+      variantsAreEqual(toggle.variant, other.variant)
     );
   });
 

--- a/src/useUnleashClientSubscription.ts
+++ b/src/useUnleashClientSubscription.ts
@@ -1,0 +1,20 @@
+import { useCallback } from 'react';
+import type { UnleashClient } from 'unleash-proxy-client';
+
+const useUnleashClientSubscription = (client?: UnleashClient) =>
+  useCallback(
+    (onStoreChange: () => void) => {
+      if (!client) return () => {};
+
+      client.on('update', onStoreChange);
+      client.on('ready', onStoreChange);
+
+      return () => {
+        client.off('update', onStoreChange);
+        client.off('ready', onStoreChange);
+      };
+    },
+    [client]
+  );
+
+export default useUnleashClientSubscription;

--- a/src/useVariant.test.tsx
+++ b/src/useVariant.test.tsx
@@ -38,10 +38,9 @@ test('should return false when the flag is NOT enabled in context', () => {
   expect(clientMock.on).toHaveBeenCalledWith('update', expect.any(Function));
   expect(clientMock.on).toHaveBeenCalledWith('ready', expect.any(Function));
   expect(result.current).toBe(givenVariantA);
-  expect(getVariantMock).toHaveBeenCalledTimes(1);
 });
 
-test('should return variant when the client is ready and re-call getVariant', () => {
+test('should return variant when the client becomes ready', () => {
   getVariantMock.mockReturnValue(givenVariantA);
   vi.mocked(useContext).mockReturnValue({
     client: clientMock,
@@ -58,12 +57,11 @@ test('should return variant when the client is ready and re-call getVariant', ()
   expect(clientMock.on).toHaveBeenCalledWith('update', expect.any(Function));
   expect(clientMock.on).toHaveBeenCalledWith('ready', expect.any(Function));
   expect(result.current).toBe(givenVariantA);
-  expect(getVariantMock).toHaveBeenCalledTimes(2);
 });
 
 test('should return `B` when the variant is first `A` and is updated with `B`', () => {
   getVariantMock.mockReturnValueOnce(givenVariantA);
-  getVariantMock.mockReturnValueOnce(givenVariantB);
+  getVariantMock.mockReturnValue(givenVariantB);
   vi.mocked(useContext).mockReturnValue({
     client: clientMock,
     getVariant: getVariantMock,
@@ -76,7 +74,6 @@ test('should return `B` when the variant is first `A` and is updated with `B`', 
 
   const { result } = renderHook(() => useVariant(givenFlagName));
 
-  expect(getVariantMock).toHaveBeenCalledTimes(3);
   expect(result.current).toBe(givenVariantB);
   expect(clientMock.on).toHaveBeenCalledWith('update', expect.any(Function));
   expect(clientMock.on).toHaveBeenCalledWith('ready', expect.any(Function));
@@ -84,7 +81,7 @@ test('should return `B` when the variant is first `A` and is updated with `B`', 
 
 test('should return `A` when the variant is first `A` and is updated with `A` disabled', () => {
   getVariantMock.mockReturnValueOnce(givenVariantA);
-  getVariantMock.mockReturnValueOnce(givenVariantA_disabled);
+  getVariantMock.mockReturnValue(givenVariantA_disabled);
   vi.mocked(useContext).mockReturnValue({
     client: clientMock,
     getVariant: getVariantMock,
@@ -97,15 +94,13 @@ test('should return `A` when the variant is first `A` and is updated with `A` di
 
   const { result } = renderHook(() => useVariant(givenFlagName));
 
-  expect(getVariantMock).toHaveBeenCalledTimes(3);
   expect(result.current).toBe(givenVariantA_disabled);
   expect(clientMock.on).toHaveBeenCalledWith('update', expect.any(Function));
   expect(clientMock.on).toHaveBeenCalledWith('ready', expect.any(Function));
 });
 
-test('should return `A` and update the local state just once when the variant is the same', () => {
-  getVariantMock.mockReturnValueOnce(givenVariantA);
-  getVariantMock.mockReturnValueOnce(givenVariantA);
+test('should not re-render when an update yields an equal variant', () => {
+  getVariantMock.mockImplementation(() => ({ name: 'A', enabled: true }));
   vi.mocked(useContext).mockReturnValue({
     client: clientMock,
     getVariant: getVariantMock,
@@ -116,16 +111,18 @@ test('should return `A` and update the local state just once when the variant is
     }
   });
 
-  const { result } = renderHook(() => useVariant(givenFlagName));
+  let renders = 0;
+  const { result } = renderHook(() => {
+    renders += 1;
+    return useVariant(givenFlagName);
+  });
 
-  expect(getVariantMock).toHaveBeenCalledTimes(2);
-  expect(result.current).toBe(givenVariantA);
-  expect(clientMock.on).toHaveBeenCalledWith('update', expect.any(Function));
-  expect(clientMock.on).toHaveBeenCalledWith('ready', expect.any(Function));
+  expect(result.current).toEqual({ name: 'A', enabled: true });
+  expect(renders).toBe(1);
 });
 
 test('should NOT subscribe to ready or update if client does NOT exist', () => {
-  getVariantMock.mockReturnValueOnce(false);
+  getVariantMock.mockReturnValue(false);
   vi.mocked(useContext).mockReturnValue({
     client: undefined,
     getVariant: getVariantMock,
@@ -140,8 +137,6 @@ test('should NOT subscribe to ready or update if client does NOT exist', () => {
 
   expect(result.current).toStrictEqual({});
   expect(clientMock.on).not.toHaveBeenCalled();
-  expect(clientMock.on).not.toHaveBeenCalled();
-  expect(getVariantMock).toHaveBeenCalledTimes(1);
 });
 
 test('should remove event listeners when unmounted', () => {

--- a/src/useVariant.test.tsx
+++ b/src/useVariant.test.tsx
@@ -159,6 +159,47 @@ test('should remove event listeners when unmounted', () => {
   expect(clientMock.off).nthCalledWith(2, ...clientMock.on.mock.calls[1]);
 });
 
+test('reconciles the variant when ready/update fired before the effect subscribed', () => {
+  // Seeded with the disabled variant at render, but the client already resolved
+  // the enabled one — the ready/update fired before we subscribed, so `on` never
+  // invokes our handlers.
+  getVariantMock.mockReturnValueOnce(givenVariantA_disabled);
+  getVariantMock.mockReturnValue(givenVariantA);
+  vi.mocked(useContext).mockReturnValue({
+    client: clientMock,
+    getVariant: getVariantMock,
+  });
+  clientMock.on.mockImplementation(() => {});
+
+  const { result } = renderHook(() => useVariant(givenFlagName));
+
+  // A correct hook re-reads on subscribe and reports the enabled variant. The
+  // buggy version stays on the disabled one.
+  expect(result.current).toBe(givenVariantA);
+});
+
+test('re-reads when the featureName argument changes', () => {
+  getVariantMock.mockImplementation((name: string) =>
+    name === 'flag-a' ? givenVariantA : givenVariantB
+  );
+  vi.mocked(useContext).mockReturnValue({
+    client: clientMock,
+    getVariant: getVariantMock,
+  });
+  clientMock.on.mockImplementation(() => {});
+
+  const { result, rerender } = renderHook(({ name }) => useVariant(name), {
+    initialProps: { name: 'flag-a' },
+  });
+  expect(result.current).toBe(givenVariantA);
+
+  // Pointing the hook at a different flag should return that flag's variant. The
+  // buggy version keeps the old one because `featureName` is missing from the
+  // effect deps.
+  rerender({ name: 'flag-b' });
+  expect(result.current).toBe(givenVariantB);
+});
+
 describe('Variant change detection', () => {
     test('If the variants are identical, it returns `false`', () => {
         const a = {

--- a/src/useVariant.test.tsx
+++ b/src/useVariant.test.tsx
@@ -1,7 +1,8 @@
 import { vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useContext } from 'react';
-import useVariant, { variantHasChanged } from './useVariant';
+import useVariant from './useVariant';
+import variantsAreEqual from './variantsAreEqual';
 
 vi.mock('react', async () => {
   const react = (await vi.importActual('react')) as any;
@@ -195,8 +196,8 @@ test('re-reads when the featureName argument changes', () => {
   expect(result.current).toBe(givenVariantB);
 });
 
-describe('Variant change detection', () => {
-    test('If the variants are identical, it returns `false`', () => {
+describe('Variant equality', () => {
+    test('If the variants are identical, it returns `true`', () => {
         const a = {
             name: 'a',
             enabled: true,
@@ -214,27 +215,27 @@ describe('Variant change detection', () => {
             },
         };
 
-        expect(variantHasChanged(a, b)).toBeFalsy();
+        expect(variantsAreEqual(a, b)).toBeTruthy();
     });
 
-    test('If the new variant is undefined, it counts as a change', () => {
+    test('If the second variant is undefined, they are not equal', () => {
         const a = { name: 'a', enabled: true };
 
-        expect(variantHasChanged(a, undefined)).toBeTruthy();
+        expect(variantsAreEqual(a, undefined)).toBeFalsy();
     });
 
     test('Name change is detected', () => {
         const a = { name: 'a', enabled: true };
         const b = { name: 'b', enabled: true };
 
-        expect(variantHasChanged(a, b)).toBeTruthy();
+        expect(variantsAreEqual(a, b)).toBeFalsy();
     });
 
     test('Enabled state change is detected', () => {
         const enabled = { name: 'a', enabled: true };
         const disabled = { name: 'a', enabled: false };
 
-        expect(variantHasChanged(enabled, disabled)).toBeTruthy();
+        expect(variantsAreEqual(enabled, disabled)).toBeFalsy();
     });
     test('Payload type change is detected', () => {
         const a = {
@@ -254,7 +255,7 @@ describe('Variant change detection', () => {
             },
         };
 
-        expect(variantHasChanged(a, b)).toBeTruthy();
+        expect(variantsAreEqual(a, b)).toBeFalsy();
     });
 
     test('Payload value change is detected', () => {
@@ -275,6 +276,6 @@ describe('Variant change detection', () => {
             },
         };
 
-        expect(variantHasChanged(a, b)).toBeTruthy();
+        expect(variantsAreEqual(a, b)).toBeFalsy();
     });
 });

--- a/src/useVariant.ts
+++ b/src/useVariant.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef } from 'react';
+import { useCallback } from 'react';
+import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
 import { IVariant } from 'unleash-proxy-client';
 import { useFlagContext } from './useFlagContext';
 
@@ -19,39 +20,31 @@ export const variantHasChanged = (
 const useVariant = (featureName: string): Partial<IVariant> => {
   const { getVariant, client } = useFlagContext();
 
-  const [variant, setVariant] = useState(getVariant(featureName));
-  const variantRef = useRef<typeof variant>({
-    name: variant.name,
-    enabled: variant.enabled,
-  });
-  variantRef.current = variant;
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!client) return () => {};
+      client.on('update', onStoreChange);
+      client.on('ready', onStoreChange);
+      return () => {
+        client.off('update', onStoreChange);
+        client.off('ready', onStoreChange);
+      };
+    },
+    [client]
+  );
 
-  useEffect(() => {
-    if (!client) return;
+  const getSnapshot = useCallback(
+    () => getVariant(featureName),
+    [getVariant, featureName]
+  );
 
-    const updateHandler = () => {
-      const newVariant = getVariant(featureName);
-      if (variantHasChanged(variantRef.current, newVariant)) {
-        setVariant(newVariant);
-        variantRef.current = newVariant;
-      }
-    };
-
-    const readyHandler = () => {
-      const variant = getVariant(featureName);
-      variantRef.current.name = variant?.name;
-      variantRef.current.enabled = variant?.enabled;
-      setVariant(variant);
-    };
-
-    client.on('update', updateHandler);
-    client.on('ready', readyHandler);
-
-    return () => {
-      client.off('update', updateHandler);
-      client.off('ready', readyHandler);
-    };
-  }, [client]);
+  const variant = useSyncExternalStoreWithSelector(
+    subscribe,
+    getSnapshot,
+    getSnapshot,
+    (value) => value,
+    (a, b) => !variantHasChanged(a, b)
+  );
 
   return variant || {};
 };

--- a/src/useVariant.ts
+++ b/src/useVariant.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
 import { IVariant } from 'unleash-proxy-client';
 import { useFlagContext } from './useFlagContext';
+import useUnleashClientSubscription from './useUnleashClientSubscription';
 
 export const variantHasChanged = (
     oldVariant: IVariant,
@@ -20,18 +21,7 @@ export const variantHasChanged = (
 const useVariant = (featureName: string): Partial<IVariant> => {
   const { getVariant, client } = useFlagContext();
 
-  const subscribe = useCallback(
-    (onStoreChange: () => void) => {
-      if (!client) return () => {};
-      client.on('update', onStoreChange);
-      client.on('ready', onStoreChange);
-      return () => {
-        client.off('update', onStoreChange);
-        client.off('ready', onStoreChange);
-      };
-    },
-    [client]
-  );
+  const subscribe = useUnleashClientSubscription(client);
 
   const getSnapshot = useCallback(
     () => getVariant(featureName),

--- a/src/useVariant.ts
+++ b/src/useVariant.ts
@@ -5,21 +5,23 @@ import { useFlagContext } from './useFlagContext';
 import useUnleashClientSubscription from './useUnleashClientSubscription';
 import variantsAreEqual from './variantsAreEqual';
 
+const selectVariant = (variant: IVariant) => variant;
+
 const useVariant = (featureName: string): Partial<IVariant> => {
   const { getVariant, client } = useFlagContext();
 
-  const subscribe = useUnleashClientSubscription(client);
+  const subscribeToUnleashClient = useUnleashClientSubscription(client);
 
-  const getSnapshot = useCallback(
+  const getVariantSnapshot = useCallback(
     () => getVariant(featureName),
     [getVariant, featureName]
   );
 
   const variant = useSyncExternalStoreWithSelector(
-    subscribe,
-    getSnapshot,
-    getSnapshot,
-    (variant) => variant,
+    subscribeToUnleashClient,
+    getVariantSnapshot,
+    getVariantSnapshot,
+    selectVariant,
     variantsAreEqual
   );
 

--- a/src/useVariant.ts
+++ b/src/useVariant.ts
@@ -3,20 +3,7 @@ import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/w
 import { IVariant } from 'unleash-proxy-client';
 import { useFlagContext } from './useFlagContext';
 import useUnleashClientSubscription from './useUnleashClientSubscription';
-
-export const variantHasChanged = (
-    oldVariant: IVariant,
-    newVariant?: IVariant,
-): boolean => {
-    const variantsAreEqual =
-        oldVariant.name === newVariant?.name &&
-        oldVariant.enabled === newVariant?.enabled &&
-        oldVariant.feature_enabled === newVariant?.feature_enabled &&
-        oldVariant.payload?.type === newVariant?.payload?.type &&
-        oldVariant.payload?.value === newVariant?.payload?.value;
-
-    return !variantsAreEqual;
-};
+import variantsAreEqual from './variantsAreEqual';
 
 const useVariant = (featureName: string): Partial<IVariant> => {
   const { getVariant, client } = useFlagContext();
@@ -32,8 +19,8 @@ const useVariant = (featureName: string): Partial<IVariant> => {
     subscribe,
     getSnapshot,
     getSnapshot,
-    (value) => value,
-    (a, b) => !variantHasChanged(a, b)
+    (variant) => variant,
+    variantsAreEqual
   );
 
   return variant || {};

--- a/src/variantsAreEqual.ts
+++ b/src/variantsAreEqual.ts
@@ -1,0 +1,13 @@
+import type { IVariant } from 'unleash-proxy-client';
+
+const variantsAreEqual = (
+  first?: IVariant,
+  second?: IVariant
+): boolean =>
+  first?.name === second?.name &&
+  first?.enabled === second?.enabled &&
+  first?.feature_enabled === second?.feature_enabled &&
+  first?.payload?.type === second?.payload?.type &&
+  first?.payload?.value === second?.payload?.value;
+
+export default variantsAreEqual;

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,7 +12,12 @@ export default defineConfig({
       fileName: 'unleash-react',
     },
     rolldownOptions: {
-      external: ['react', 'unleash-proxy-client'],
+      external: [
+        'react',
+        'unleash-proxy-client',
+        'use-sync-external-store/shim',
+        'use-sync-external-store/shim/with-selector',
+      ],
       output: {
         exports: 'named',
         globals: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,6 +311,11 @@
   dependencies:
     csstype "^3.2.2"
 
+"@types/use-sync-external-store@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz#222c28a98eb8f4f8a72c1a7e9fe6d8946eca6383"
+  integrity sha512-5dyB8nLC/qogMrlCizZnYWQTA4lnb/v+It+sqNl5YnSRAPMlIqY/X0Xn+gZw8vOL+TgTTr28VEbn3uf8fUtAkw==
+
 "@vitest/coverage-v8@^4.1.2":
   version "4.1.8"
   resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz#6a5dd34552840a0ace0396d0e94c7459beb80d14"
@@ -1411,6 +1416,11 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+use-sync-external-store@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
 
 "vite@^6.0.0 || ^7.0.0 || ^8.0.0", vite@^8.0.3:
   version "8.0.16"


### PR DESCRIPTION
## What's going on

`useFlag`, `useFlags`, and `useVariant` could give you the wrong value in a couple of situations (there's more detail and a repro in #247).

The PR has two commits:

1. Adds tests that fail and highlight the two bugs (check out this commit on its own and run the tests, they should fail).
2. Fixes both bugs by switching the hooks to `useSyncExternalStore`.

Fixes #247.

## Why useSyncExternalStore

The Unleash client is pretty much what `useSyncExternalStore` was made for: some external thing that holds state and lets you know when it changes.

A few benefits of using `useSyncExternalStore`:

- It re-reads the value right after subscribing, so if the client became ready in that gap between rendering and subscribing (bug number 2 in the issue), we catch it instead of getting stuck on the stale value.
- `getSnapshot` reads the current `featureName` on every render, so changing the flag name just works and there's no dependency array to keep in sync.
- On React 18+ a render can pause and resume, so a flag could change halfway through this pause and leave different components showing different values in the same render. `useSyncExternalStore` coordinates with React so every subscriber sees one consistent value per render.

## Why the withSelector version for useFlags/useVariant

`useSyncExternalStore` expects `getSnapshot` to return the same reference when nothing changed, otherwise it re-renders over and over. But `getVariant()` and `getAllToggles()` return a new object/array every time they are called, which React would interpret as always being different. `useSyncExternalStoreWithSelector` lets us pass our own equality check (`variantHasChanged`, `togglesAreEqual`), so when nothing meaningful changed it gives back the previous reference. It's a bit of a niche hook that isn't available in React itself, but that is maintained and published in the shim by the React team, exactly for these purposes.

Note: `useFlag` just returns a boolean, so it compares fine by value and uses the plain `useSyncExternalStore`.

## Why add use-sync-external-store

Two reasons:

- **Older React support.** `useSyncExternalStore` only exists in React 18+, but the Unleash SDK still lists React 16.8 and 17 as supported peers. The [`use-sync-external-store`](https://www.npmjs.com/package/use-sync-external-store) package is the React team's own backport: it uses the built-in hook on 18+ and a shim on older versions, so nothing breaks for people still on older React.
- **`useSyncExternalStoreWithSelector` doesn't ship in React at all.** As mentioned above, the selector variant lives only in this package, even on React 18+ — so we'd need the dependency for `useFlags`/`useVariant` regardless of which React versions we supported.

## Note

Since there are no contributing guidelines, I'm not sure exactly what's expected here. The tests pass for me locally after switching to `useSyncExternalStore`, and I packed the change into a tarball and tried it out in our own application (worked great), but I'm happy to do whatever else helps to test this.
